### PR TITLE
Support label in GitHub check JSON object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+-   A `label` can now be set in the GitHub check JSON object.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [0.4.0] 2019-05-08

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -334,7 +334,7 @@ async function automaticMode(
 
   let reportGitHubCheckResults;
   if (opts['github-check'] !== '') {
-    const {appId, installationId, repo, commit} =
+    const {label, appId, installationId, repo, commit} =
         github.parseCheckFlag(opts['github-check']);
 
     // We can directly store our GitHub App private key as a secret Travis
@@ -363,14 +363,14 @@ async function automaticMode(
     // Create the initial Check Run run now, so that it will show up in the
     // GitHub UI as pending.
     const checkId =
-        await github.createCheckRun({repo, commit, installationToken});
+        await github.createCheckRun({label, repo, commit, installationToken});
 
     // We'll call this after we're done to complete the Check Run.
     reportGitHubCheckResults = async ({fixed, unfixed}: AutomaticResults) => {
       const markdown = horizontalHtmlResultTable(fixed) + '\n' +
           verticalHtmlResultTable(unfixed);
       await github.completeCheckRun(
-          {repo, installationToken, checkId, markdown});
+          {label, repo, installationToken, checkId, markdown});
     };
   }
 


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/41

Will allow us to tell the difference between PR vs branch Tachometer runs.