### PR TITLE
Update config files with reference to the schema, if absent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+-   Automatically update config files with a $schema property, pointing to
+    the JSON schema for the file on unpkg. This will provide in-editor
+    contextual help for many IDEs (like VS Code) when writing
+    tachometer config files.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [0.4.2] 2019-06-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -359,6 +359,12 @@
       "resolved": "https://registry.npmjs.org/@types/table/-/table-4.0.5.tgz",
       "integrity": "sha512-M/e/pWOWjm8X/fu8I9eOhc/ww1RsUG1yOr/G3vgdBwVFmfnMiqCRIiEKpDZdscNNCzr/kAAzuTNqGUH1uAk/qQ=="
     },
+    "@types/tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
+      "dev": true
+    },
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
@@ -2755,6 +2761,16 @@
         "rimraf": "^2.5.4",
         "tmp": "0.0.30",
         "xml2js": "^0.4.17"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.30",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        }
       }
     },
     "semver": {
@@ -3006,11 +3022,12 @@
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
     },
     "tmp": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "rimraf": "^2.6.3"
       }
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -76,9 +76,11 @@
     "@babel/types": "^7.4.4",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.6",
+    "@types/tmp": "^0.1.0",
     "chai": "^4.2.0",
     "clang-format": "^1.2.4",
     "mocha": "^6.0.2",
+    "tmp": "^0.1.0",
     "tslint": "^5.12.1",
     "typescript": "^3.2.0",
     "typescript-json-schema": "^0.38.3"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -287,10 +287,24 @@ $ tach http://example.com
       throw new Error(
           '--resolve-bare-modules cannot be specified when using --config');
     }
+    const rawConfigObj = await fsExtra.readJson(opts.config);
+    const validatedConfigObj = await parseConfigFile(rawConfigObj);
+
+    // Add the $schema field to the original config file if it's absent.
+    // We only want to do this if the file validated though, so we don't mutate
+    // a file that's not actually a tachometer config file.
+    if (!('$schema' in rawConfigObj)) {
+      // Extra IDE features can be activated if the config file has a schema.
+      const withSchema = {
+        ...rawConfigObj,
+        '$schema': 'https://unpkg.com/tachometer/lib/config.schema.json'
+      };
+      await fsExtra.writeFile(opts.config, JSON.stringify(withSchema, null, 2));
+    }
+
     config = {
       ...baseConfig,
-      ...await parseConfigFile(
-          await fsExtra.readJson(opts.config), opts.config),
+      ...validatedConfigObj,
     };
 
   } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -289,7 +289,8 @@ $ tach http://example.com
     }
     config = {
       ...baseConfig,
-      ...await parseConfigFile(await fsExtra.readJson(opts.config)),
+      ...await parseConfigFile(
+          await fsExtra.readJson(opts.config), opts.config),
     };
 
   } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,8 +296,8 @@ $ tach http://example.com
     if (!('$schema' in rawConfigObj)) {
       // Extra IDE features can be activated if the config file has a schema.
       const withSchema = {
+        '$schema': 'https://unpkg.com/tachometer/lib/config.schema.json',
         ...rawConfigObj,
-        '$schema': 'https://unpkg.com/tachometer/lib/config.schema.json'
       };
       await fsExtra.writeFile(opts.config, JSON.stringify(withSchema, null, 2));
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,6 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import * as fs from 'fs-extra';
 import * as jsonschema from 'jsonschema';
 import * as path from 'path';
 
@@ -162,8 +161,7 @@ export function defaultMeasurement(url: LocalUrl|RemoteUrl): Measurement {
  * Validate the given JSON object parsed from a config file, and expand it into
  * a fully specified configuration.
  */
-export async function parseConfigFile(
-    parsedJson: unknown, configFilename?: string): Promise<Config> {
+export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
   const schema = require('./config.schema.json');
   const result =
       jsonschema.validate(parsedJson, schema, {propertyName: 'config'});
@@ -171,12 +169,6 @@ export async function parseConfigFile(
     throw new Error(result.errors[0].toString());
   }
   const validated = parsedJson as ConfigFile;
-  if (!('$schema' in validated) && configFilename) {
-    // Extra IDE features can be activated if the config file has a schema.
-    validated.$schema = 'https://unpkg.com/tachometer/lib/config.schema.json';
-    await fs.writeFile(configFilename, JSON.stringify(validated, null, 2));
-  }
-
   const root = validated.root || '.';
   const benchmarks: BenchmarkSpec[] = [];
   for (const benchmark of validated.benchmarks) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,12 @@ export interface ConfigFile {
    */
   resolveBareModules?: boolean;
 
+  /**
+   * An optional reference to the JSON Schema for this file.
+   *
+   * If none is given, and the file is a valid tachometer config file,
+   * tachometer will write back to the config file to give this a value.
+   */
   $schema?: string;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import * as fs from 'fs-extra';
 import * as jsonschema from 'jsonschema';
 import * as path from 'path';
 
@@ -60,6 +61,8 @@ export interface ConfigFile {
    * specifiers to paths.
    */
   resolveBareModules?: boolean;
+
+  $schema?: string;
 }
 
 /**
@@ -159,7 +162,8 @@ export function defaultMeasurement(url: LocalUrl|RemoteUrl): Measurement {
  * Validate the given JSON object parsed from a config file, and expand it into
  * a fully specified configuration.
  */
-export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
+export async function parseConfigFile(
+    parsedJson: unknown, configFilename?: string): Promise<Config> {
   const schema = require('./config.schema.json');
   const result =
       jsonschema.validate(parsedJson, schema, {propertyName: 'config'});
@@ -167,6 +171,11 @@ export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
     throw new Error(result.errors[0].toString());
   }
   const validated = parsedJson as ConfigFile;
+  if (!('$schema' in validated) && configFilename) {
+    // Extra IDE features can be activated if the config file has a schema.
+    validated.$schema = 'https://unpkg.com/tachometer/lib/config.schema.json';
+    await fs.writeFile(configFilename, JSON.stringify(validated, null, 2));
+  }
 
   const root = validated.root || '.';
   const benchmarks: BenchmarkSpec[] = [];

--- a/src/test/config_test.ts
+++ b/src/test/config_test.ts
@@ -11,9 +11,7 @@
 
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as tmp from 'tmp';
 
 chai.use(chaiAsPromised);
 const {assert} = chai;
@@ -220,25 +218,6 @@ suite('config', () => {
       const actual = await parseConfigFile(config);
       assert.deepEqual(actual, expected);
     });
-
-    test(
-        'it updates an on-disk config file with the schema, if absent',
-        async () => {
-          const config = {
-            benchmarks: [{
-              url: 'http://example.com?foo=bar',
-            }],
-          };
-          const expectedUpdatedConfig = {
-            $schema: 'https://unpkg.com/tachometer/lib/config.schema.json',
-            ...config
-          };
-          const tempFile = tmp.fileSync();
-          fs.writeJSONSync(tempFile.name, config);
-          await parseConfigFile(config, tempFile.name);
-          assert.deepEqual(
-              fs.readJsonSync(tempFile.name), expectedUpdatedConfig);
-        });
 
     suite('errors', () => {
       test('invalid top-level type', async () => {


### PR DESCRIPTION
Automatically update config files with a $schema property, pointing to
the JSON schema for the file on unpkg. This will provide in-editor
contextual help for many IDEs (like VS Code) when writing
tachometer config files.