### PR TITLE
Add tachometer bin alias, some minor tweaks, and release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
--   Automatically update config files with a $schema property, pointing to
-    the JSON schema for the file on unpkg. This will provide in-editor
-    contextual help for many IDEs (like VS Code) when writing
-    tachometer config files.
+-   Automatically update config files with a `$schema` property, pointing to the
+    JSON schema for the file on unpkg. This will provide in-editor contextual
+    help for many IDEs (like VS Code) when writing tachometer config files.
 
 -   Add `tachometer` bin alias, so that `npx tachometer` can be used (previously
     the binary could only be invoked as `tach`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new, unreleased changes here. -->
+
+## [0.4.3] 2019-06-08
 
 -   Automatically update config files with a `$schema` property, pointing to the
     JSON schema for the file on unpkg. This will provide in-editor contextual
@@ -13,8 +16,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Add `tachometer` bin alias, so that `npx tachometer` can be used (previously
     the binary could only be invoked as `tach`).
-
-<!-- Add new, unreleased changes here. -->
 
 ## [0.4.2] 2019-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
     contextual help for many IDEs (like VS Code) when writing
     tachometer config files.
 
+-   Add `tachometer` bin alias, so that `npx tachometer` can be used (previously
+    the binary could only be invoked as `tach`).
+
 <!-- Add new, unreleased changes here. -->
 
 ## [0.4.2] 2019-06-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -141,6 +141,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
       "integrity": "sha512-y9KJUf19SBowoaqhWdQNnErxFMNsKbuair2i3SGv5Su1ExLPAJz37iPXLHKIFQGYkHGxsSe45rNt8ZekXxJwUw=="
+    },
+    "@types/babel__generator": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
     },
     "@types/body-parser": {
       "version": "1.17.0",
@@ -358,12 +367,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/table/-/table-4.0.5.tgz",
       "integrity": "sha512-M/e/pWOWjm8X/fu8I9eOhc/ww1RsUG1yOr/G3vgdBwVFmfnMiqCRIiEKpDZdscNNCzr/kAAzuTNqGUH1uAk/qQ=="
-    },
-    "@types/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
-      "dev": true
     },
     "@types/tough-cookie": {
       "version": "2.3.5",
@@ -1919,9 +1922,9 @@
       }
     },
     "koa-node-resolve": {
-      "version": "1.0.0-pre.3",
-      "resolved": "https://registry.npmjs.org/koa-node-resolve/-/koa-node-resolve-1.0.0-pre.3.tgz",
-      "integrity": "sha512-8zxc8cn+XsFQk04FMmLSi7aD3XOuHUa2g1HiYk47zBbwQAc/07Fc2Xv1jNMbC13564eCwfDL/HxjWZzSajRFYw==",
+      "version": "1.0.0-pre.4",
+      "resolved": "https://registry.npmjs.org/koa-node-resolve/-/koa-node-resolve-1.0.0-pre.4.tgz",
+      "integrity": "sha512-cBtAt89xRJT3cjiXKCqVyEb09h9Jjkx73Wm60CSurSnqJIDi55AS8PM2BHTzgTpjNgTyg4yB0yQ5XLUEnrlk1A==",
       "requires": {
         "@babel/generator": "^7.4.4",
         "@babel/parser": "^7.4.5",
@@ -2761,16 +2764,6 @@
         "rimraf": "^2.5.4",
         "tmp": "0.0.30",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -3022,12 +3015,11 @@
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
     },
     "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dev": true,
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
       "requires": {
-        "rimraf": "^2.6.3"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-fast-properties": {
@@ -3212,9 +3204,9 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/PolymerLabs/tachometer#readme",
   "dependencies": {
-    "@babel/parser": "^7.4.5",
     "@types/ansi-escape-sequences": "^4.0.0",
     "@types/chai-as-promised": "^7.1.0",
     "@types/command-line-args": "^5.0.0",
@@ -61,7 +60,7 @@
     "koa": "^2.5.1",
     "koa-bodyparser": "^4.2.1",
     "koa-mount": "^4.0.0",
-    "koa-node-resolve": "^1.0.0-pre.3",
+    "koa-node-resolve": "^1.0.0-pre.4",
     "koa-router": "^7.4.0",
     "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",
@@ -74,7 +73,7 @@
     "ua-parser-js": "^0.7.19"
   },
   "devDependencies": {
-    "@babel/types": "^7.4.4",
+    "@types/babel__generator": "^7.0.2",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.6",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lib": "lib"
   },
   "bin": {
-    "tach": "bin/tach.js"
+    "tach": "bin/tach.js",
+    "tachometer": "bin/tach.js"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Web benchmark runner",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -77,11 +77,9 @@
     "@babel/types": "^7.4.4",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.6",
-    "@types/tmp": "^0.1.0",
     "chai": "^4.2.0",
     "clang-format": "^1.2.4",
     "mocha": "^6.0.2",
-    "tmp": "^0.1.0",
     "tslint": "^5.12.1",
     "typescript": "^3.2.0",
     "typescript-json-schema": "^0.38.3"

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,6 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {parse as babelParse} from '@babel/parser';
 import * as http from 'http';
 import * as net from 'net';
 import * as path from 'path';
@@ -86,19 +85,7 @@ export class Server {
     app.use(this.serveBenchLib.bind(this));
 
     if (opts.resolveBareModules === true) {
-      app.use(nodeResolve({
-        root: opts.root,
-        // Only log errors.
-        logger: {...console, debug: undefined, info: undefined},
-        // Enable latest JS syntax.
-        jsParser: (js) => babelParse(js, {
-          sourceType: 'unambiguous',
-          plugins: [
-            'dynamicImport',
-            'importMeta',
-          ],
-        }),
-      }));
+      app.use(nodeResolve({root: opts.root}));
     }
     for (const {diskPath, urlPath} of opts.mountPoints) {
       app.use(mount(urlPath, serve(diskPath, {index: 'index.html'})));


### PR DESCRIPTION
If you run `npx foo`, it will:
1) Find and run the binary called `foo` in your nearest `node_modules/.bin` (no matter what package it comes from).
2) If the binary wasn't found, temporarily install the latest package `foo` and run its binary (no matter what its binary name is).

In our case, `tach` is our binary, but `tachometer` is our package, and `tach` is a totally unrelated package.

So, if you already have `tachometer` installed, `npx tach` works fine. But if you don't, it will install `tach` (the wrong package), and then fail because package `tach` has no binary (or worse, run a malicious package).

Even weirder, if `tachometer` *is* installed, but you run `npx tachometer`, then it won't notice that `tachometer` is already installed (since for step 1 it only checks the binary name), and will instead needlessly temporarily install and run the latest version of `tachometer`.

So, this adds `tachometer` as a bin alias, so that step 1 works correctly and we can always recommend `npx tachometer`. Maybe in the next major version we can drop the `tach` binary name so that nobody is tempted to run `npx tach`.