### PR TITLE
Temporarily disable koa-node-resolve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
 
+## [0.4.4] 2019-06-08
+
+-  Remove noisy debug logging for bare module import resolution.
+
 ## [0.4.3] 2019-06-08
 
 -   Automatically update config files with a `$schema` property, pointing to the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Web benchmark runner",
   "main": "index.js",
   "directories": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,7 +85,13 @@ export class Server {
     app.use(this.serveBenchLib.bind(this));
 
     if (opts.resolveBareModules === true) {
-      app.use(nodeResolve({root: opts.root}));
+      app.use(nodeResolve({
+        root: opts.root,
+        // TODO Use default logging options after issues resolved:
+        // https://github.com/Polymer/koa-node-resolve/issues/16
+        // https://github.com/Polymer/koa-node-resolve/issues/17
+        logger: false,
+      }));
     }
     for (const {diskPath, urlPath} of opts.mountPoints) {
       app.use(mount(urlPath, serve(diskPath, {index: 'index.html'})));


### PR DESCRIPTION
Getting some noisy debug logging with default logging options due to:

https://github.com/Polymer/koa-node-resolve/issues/16
https://github.com/Polymer/koa-node-resolve/issues/17

Disable for now, and release 0.4.4