### PR TITLE
Write a versioned URL for the schema.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "definitions": {
+        "ConfigFileBenchmark": {
+            "additionalProperties": false,
+            "description": "Expected format of a benchmark in a JSON config file.",
+            "properties": {
+                "browser": {
+                    "description": "Which browser to run the benchmark in.\n\nOptions:\n   - chrome (default)\n   - chrome-headless\n   - firefox\n   - firefox-headless\n   - safari",
+                    "enum": [
+                        "chrome",
+                        "chrome-headless",
+                        "firefox",
+                        "firefox-headless",
+                        "safari"
+                    ],
+                    "type": "string"
+                },
+                "expand": {
+                    "description": "Recursively expand this benchmark configuration with any number of\nvariations. Useful for testing the same base configuration with e.g.\nmultiple browers or package versions.",
+                    "items": {
+                        "$ref": "#/definitions/ConfigFileBenchmark"
+                    },
+                    "type": "array"
+                },
+                "measurement": {
+                    "description": "Which time interval to measure.\n\nOptions:\n   - callback: bench.start() to bench.stop() (default for fully qualified\n     URLs.\n   - fcp: first contentful paint (default for local paths)",
+                    "enum": [
+                        "callback",
+                        "fcp"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "description": "An optional label for this benchmark. Defaults to the URL.",
+                    "type": "string"
+                },
+                "packageVersions": {
+                    "$ref": "#/definitions/ConfigFilePackageVersion",
+                    "description": "Optional NPM dependency overrides to apply and install. Only supported with\nlocal paths."
+                },
+                "url": {
+                    "description": "A fully qualified URL, or a local path to an HTML file or directory. If a\ndirectory, must contain an index.html. Query parameters are permitted on\nlocal paths (e.g. \"my/benchmark.html?foo=bar\").",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ConfigFilePackageVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "dependencies": {
+                    "$ref": "#/definitions/PackageDependencyMap",
+                    "description": "Map from NPM package to version. Any version syntax supported by NPM is\nsupported here."
+                },
+                "label": {
+                    "description": "Required label to identify this version map.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dependencies",
+                "label"
+            ],
+            "type": "object"
+        },
+        "PackageDependencyMap": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "A mapping from NPM package name to version specifier, as used in a\npackage.json's \"dependencies\" and \"devDependencies\".",
+            "type": "object"
+        }
+    },
+    "description": "Expected format of the top-level JSON config file. Note this interface is\nused to generate the JSON schema for validation.",
+    "properties": {
+        "$schema": {
+            "description": "An optional reference to the JSON Schema for this file.\n\nIf none is given, and the file is a valid tachometer config file,\ntachometer will write back to the config file to give this a value.",
+            "type": "string"
+        },
+        "benchmarks": {
+            "description": "Benchmarks to run.",
+            "items": {
+                "$ref": "#/definitions/ConfigFileBenchmark"
+            },
+            "minItems": 1,
+            "type": "array"
+        },
+        "horizons": {
+            "description": "The degrees of difference to try and resolve when auto-sampling\n(e.g. 0ms, +1ms, -1ms, 0%, +1%, -1%, default 0%).",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "resolveBareModules": {
+            "description": "Whether to automatically convert ES module imports with bare module\nspecifiers to paths.",
+            "type": "boolean"
+        },
+        "root": {
+            "description": "Root directory to serve benchmarks from (default current directory).",
+            "type": "string"
+        },
+        "sampleSize": {
+            "description": "Minimum number of times to run each benchmark (default 50).",
+            "minimum": 2,
+            "type": "integer"
+        },
+        "timeout": {
+            "description": "The maximum number of minutes to spend auto-sampling (default 3).",
+            "minimum": 0,
+            "type": "number"
+        }
+    },
+    "required": [
+        "benchmarks"
+    ],
+    "type": "object"
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "rm -rf lib/ client/lib/ && mkdir lib/ && npm run generate-json-schema && tsc && tsc -p client/ && npm run lint",
-    "generate-json-schema": "typescript-json-schema tsconfig.json ConfigFile --include src/config.ts --required --noExtraProps > lib/config.schema.json",
+    "generate-json-schema": "typescript-json-schema tsconfig.json ConfigFile --include src/config.ts --required --noExtraProps > config.schema.json",
     "lint": "tslint --project . --format stylish",
     "format": "find src/ client/src/ -name \"*.ts\" | xargs clang-format --style=file -i",
     "test": "npm run build && mocha"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import {Horizons, ResultStats, horizonsResolved, summaryStats, computeDifference
 import {specsFromOpts} from './specs';
 import {AutomaticResults, verticalTermResultTable, horizontalTermResultTable, verticalHtmlResultTable, horizontalHtmlResultTable, automaticResultTable, spinner} from './format';
 import {prepareVersionDirectory, makeServerPlans} from './versions';
-import {parseConfigFile, Config, defaultRoot, defaultBrowser, defaultSampleSize, defaultTimeout, defaultHorizons} from './config';
+import {parseConfigFile, Config, defaultRoot, defaultBrowser, defaultSampleSize, defaultTimeout, defaultHorizons, writeBackSchemaIfNeeded} from './config';
 import * as github from './github';
 
 const defaultInstallDir = path.join(os.tmpdir(), 'tachometer', 'versions');
@@ -290,17 +290,7 @@ $ tach http://example.com
     const rawConfigObj = await fsExtra.readJson(opts.config);
     const validatedConfigObj = await parseConfigFile(rawConfigObj);
 
-    // Add the $schema field to the original config file if it's absent.
-    // We only want to do this if the file validated though, so we don't mutate
-    // a file that's not actually a tachometer config file.
-    if (!('$schema' in rawConfigObj)) {
-      // Extra IDE features can be activated if the config file has a schema.
-      const withSchema = {
-        '$schema': 'https://unpkg.com/tachometer/lib/config.schema.json',
-        ...rawConfigObj,
-      };
-      await fsExtra.writeFile(opts.config, JSON.stringify(withSchema, null, 2));
-    }
+    await writeBackSchemaIfNeeded(rawConfigObj, opts.config);
 
     config = {
       ...baseConfig,

--- a/src/config.ts
+++ b/src/config.ts
@@ -335,17 +335,14 @@ export async function writeBackSchemaIfNeeded(
   // Add the $schema field to the original config file if it's absent.
   // We only want to do this if the file validated though, so we don't mutate
   // a file that's not actually a tachometer config file.
-  if (!('$schema' in rawConfigObj) ||
-      (rawConfigObj.$schema &&
-       rawConfigObj.$schema.startsWith('https://unpkg.com/tachometer'))) {
+  if (!('$schema' in rawConfigObj)) {
+    const $schema =
+        'https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json';
     // Extra IDE features can be activated if the config file has a schema.
     const withSchema = {
-      '$schema': ``,  // write it empty, to get the key ordering correct
+      $schema,
       ...rawConfigObj,
     };
-    // Then write the value, ensuring that we overwrite rawConfigObj.$schema
-    withSchema.$schema =
-        `https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json`;
     const contents = JSON.stringify(withSchema, null, 2);
     await fsExtra.writeFile(configFile, contents, {encoding: 'utf-8'});
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,9 +21,6 @@ import {Horizons} from './stats';
 import {BenchmarkSpec, LocalUrl, Measurement, PackageDependencyMap, RemoteUrl} from './types';
 import {fileKind} from './versions';
 
-const {version: tachometerVersion} =
-    require('../package.json') as {version: string};
-
 /**
  * Expected format of the top-level JSON config file. Note this interface is
  * used to generate the JSON schema for validation.
@@ -172,7 +169,7 @@ export function defaultMeasurement(url: LocalUrl|RemoteUrl): Measurement {
  * a fully specified configuration.
  */
 export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
-  const schema = require('./config.schema.json');
+  const schema = require('../config.schema.json');
   const result =
       jsonschema.validate(parsedJson, schema, {propertyName: 'config'});
   if (result.errors.length > 0) {
@@ -347,8 +344,8 @@ export async function writeBackSchemaIfNeeded(
       ...rawConfigObj,
     };
     // Then write the value, ensuring that we overwrite rawConfigObj.$schema
-    withSchema.$schema = `https://unpkg.com/tachometer@${
-        tachometerVersion}/lib/config.schema.json`;
+    withSchema.$schema =
+        `https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json`;
     const contents = JSON.stringify(withSchema, null, 2);
     await fsExtra.writeFile(configFile, contents, {encoding: 'utf-8'});
   }


### PR DESCRIPTION
Works around an issue where IDEs may not follow redirects. This is also more correct, as it will ensure the schema matches the version of tachometer being used.