### PR TITLE
Refactor and add structure to browser handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+-   Fix bug where no browser other than Chrome could be launched.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [0.4.5] 2019-06-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Fix bug where no browser other than Chrome could be launched.
 
+-   Fix bug where process did not exit on most exceptions.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [0.4.5] 2019-06-10

--- a/config.schema.json
+++ b/config.schema.json
@@ -8,13 +8,6 @@
             "properties": {
                 "browser": {
                     "description": "Which browser to run the benchmark in.\n\nOptions:\n   - chrome (default)\n   - chrome-headless\n   - firefox\n   - firefox-headless\n   - safari",
-                    "enum": [
-                        "chrome",
-                        "chrome-headless",
-                        "firefox",
-                        "firefox-headless",
-                        "safari"
-                    ],
                     "type": "string"
                 },
                 "expand": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -327,7 +327,7 @@ $ tach http://example.com
   }
 
   for (const spec of config.benchmarks) {
-    if (!fcpBrowsers.has(spec.browser)) {
+    if (spec.measurement === 'fcp' && !fcpBrowsers.has(spec.browser)) {
       throw new Error(
           `Browser ${spec.browser} does not support the ` +
           `first contentful paint (FCP) measurement`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ import * as fsExtra from 'fs-extra';
 import * as jsonschema from 'jsonschema';
 import * as path from 'path';
 
-import {Browser} from './browser';
+import {parseAndValidateBrowser} from './browser';
 import {parseHorizons} from './cli';
 import {CheckConfig} from './github';
 import {isUrl} from './specs';
@@ -97,7 +97,7 @@ interface ConfigFileBenchmark {
    *   - firefox-headless
    *   - safari
    */
-  browser?: Browser;
+  browser?: string;
 
   /**
    * Which time interval to measure.
@@ -152,7 +152,7 @@ export interface Config {
 }
 
 export const defaultRoot = '.';
-export const defaultBrowser: Browser = 'chrome';
+export const defaultBrowser = 'chrome';
 export const defaultSampleSize = 50;
 export const defaultTimeout = 3;
 export const defaultHorizons = ['0%'];
@@ -210,6 +210,7 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
     spec.name = benchmark.name;
   }
   if (benchmark.browser !== undefined) {
+    parseAndValidateBrowser(benchmark.browser);
     spec.browser = benchmark.browser;
   }
   if (benchmark.measurement !== undefined) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,9 +16,9 @@ import * as path from 'path';
 import {parseAndValidateBrowser} from './browser';
 import {parseHorizons} from './cli';
 import {CheckConfig} from './github';
-import {isUrl} from './specs';
 import {Horizons} from './stats';
 import {BenchmarkSpec, LocalUrl, Measurement, PackageDependencyMap, RemoteUrl} from './types';
+import {isUrl} from './util';
 import {fileKind} from './versions';
 
 /**

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -12,7 +12,7 @@
 import * as path from 'path';
 import {URL} from 'url';
 
-import {validBrowsers} from './browser';
+import {parseAndValidateBrowser} from './browser';
 import {Opts} from './cli';
 import {defaultBrowser, defaultMeasurement, defaultRoot, urlFromLocalPath} from './config';
 import {BenchmarkSpec, LocalUrl, PackageVersion, RemoteUrl} from './types';
@@ -32,11 +32,7 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
     throw new Error('At least one --browser must be specified');
   }
   for (const b of browsers) {
-    if (validBrowsers.has(b) === false) {
-      throw new Error(
-          `Browser ${b} is not supported, ` +
-          `only ${[...validBrowsers].join(', ')} are currently supported`);
-    }
+    parseAndValidateBrowser(b);
   }
 
   const specs: BenchmarkSpec[] = [];

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -10,12 +10,12 @@
  */
 
 import * as path from 'path';
-import {URL} from 'url';
 
 import {parseAndValidateBrowser} from './browser';
 import {Opts} from './cli';
 import {defaultBrowser, defaultMeasurement, defaultRoot, urlFromLocalPath} from './config';
 import {BenchmarkSpec, LocalUrl, PackageVersion, RemoteUrl} from './types';
+import {isUrl} from './util';
 import {parsePackageVersions} from './versions';
 
 /**
@@ -149,13 +149,4 @@ function parseBenchmarkArgument(str: string):
     diskPath: str,
     queryString: queryString,
   };
-}
-
-export function isUrl(str: string): boolean {
-  try {
-    new URL(str);
-    return true;
-  } catch (e) {
-    return false;
-  }
 }

--- a/src/test/browser_test.ts
+++ b/src/test/browser_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import {parseAndValidateBrowser} from '../browser';
+
+suite('browser', () => {
+  suite('parseAndValidateBrowser', () => {
+    test('chrome', () => {
+      assert.deepEqual(parseAndValidateBrowser('chrome'), {
+        name: 'chrome',
+        headless: false,
+      });
+    });
+
+    test('chrome-headless', () => {
+      assert.deepEqual(parseAndValidateBrowser('chrome-headless'), {
+        name: 'chrome',
+        headless: true,
+      });
+    });
+
+    test('firefox', () => {
+      assert.deepEqual(parseAndValidateBrowser('firefox'), {
+        name: 'firefox',
+        headless: false,
+      });
+    });
+
+    test('firefox-headless', () => {
+      assert.deepEqual(parseAndValidateBrowser('firefox-headless'), {
+        name: 'firefox',
+        headless: true,
+      });
+    });
+
+    test('safari', () => {
+      assert.deepEqual(parseAndValidateBrowser('safari'), {
+        name: 'safari',
+        headless: false,
+      });
+    });
+
+    suite('errors', () => {
+      test('unsupported browser', () => {
+        assert.throws(
+            () => parseAndValidateBrowser('potato'),
+            /browser potato is not supported/i);
+      });
+
+      test('headless not supported', () => {
+        assert.throws(
+            () => parseAndValidateBrowser('safari-headless'),
+            /browser safari does not support headless/i);
+      });
+    });
+  });
+});

--- a/src/test/config_test.ts
+++ b/src/test/config_test.ts
@@ -309,8 +309,7 @@ suite('config', () => {
           }],
         };
         await assert.isRejected(
-            parseConfigFile(config),
-            'config.benchmarks[0].browser is not one of enum values: chrome');
+            parseConfigFile(config), 'Browser potato is not supported');
       });
 
       test('invalid measurement', async () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {URL} from 'url';
+
+/** Return whether the given string is a valid URL. */
+export function isUrl(str: string): boolean {
+  try {
+    new URL(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
This adds some more structured handling of browser configuration, to prepare for the next PR which adds remote webdriver support. Progress towards https://github.com/Polymer/tachometer/issues/48

Also fixes https://github.com/Polymer/tachometer/issues/58 where only Chrome could be launched.

Also fixes a bug where exceptions wouldn't exit the process, because the server continued to listen indefinitely.

cc @sorvell 