### PR TITLE
Add support for Edge on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+-   Add support for Edge in Windows (`--browser=edge`).
+
 -   Fix bug where no browser other than Chrome could be launched.
 
 -   Fix bug where process did not exit on most exceptions.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,23 @@ imports using Node-style module resolution (e.g.`import {foo} from
 This feature can be disabled with the `--resolve-bare-modules=false` flag, or
 the `resolveBareModules: false` JSON config file property.
 
+## Browsers
+
+Browser | Headless | [FCP](#first-contentful-paint-fcp)
+------- | -------- | ---
+chrome  | yes      | yes
+firefox | yes      | no
+safari  | no       | no
+edge    | no       | no
+
+To launch a headless browser, append `-headless` to the browser name (e.g. `--browser=chrome-headless`).
+
+Tachometer comes with WebDriver plugins for Chrome, Safari, and Firefox.
+
+For Edge, follow the [Microsoft WebDriver
+installation](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
+documentation.
+
 ## Config file
 
 Use the `--config` flag to control tachometer with a JSON configuration file.
@@ -391,7 +408,7 @@ Flag                      | Default     | Description
 `--port`                  | `8080, 8081, ..., 0`| Which port to run on (comma-delimited preference list, `0` for random)
 `--config`                | *(none)*    | Path to JSON config file ([details](#config-file))
 `--package-version` / `-p`| *(none)*    | Specify an NPM package version to swap in ([details](#swap-npm-dependency-versions))
-`--browser` / `-b`        | `chrome`    | Which browsers to launch in automatic mode, comma-delimited (chrome, chrome-headless, firefox, firefox-headless, safari)
+`--browser` / `-b`        | `chrome`    | Which browsers to launch in automatic mode, comma-delimited (chrome, firefox, safari, edge) ([details](#browsers))
 `--sample-size` / `-n`    | `50`        | Minimum number of times to run each benchmark ([details](#sample-size)]
 `--horizon`               | `10%`       | The degrees of difference to try and resolve when auto-sampling ("N%" or "Nms", comma-delimited) ([details](#auto-sampling))
 `--timeout`               | `3`         | The maximum number of minutes to spend auto-sampling ([details](#auto-sampling))

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "rm -rf lib/ client/lib/ && mkdir lib/ && npm run generate-json-schema && tsc && tsc -p client/ && npm run lint",
+    "build": "rm -rf lib/ client/lib/ && mkdir lib && npm run generate-json-schema && tsc && tsc -p client/ && npm run lint",
     "generate-json-schema": "typescript-json-schema tsconfig.json ConfigFile --include src/config.ts --required --noExtraProps > config.schema.json",
     "lint": "tslint --project . --format stylish",
     "format": "find src/ client/src/ -name \"*.ts\" | xargs clang-format --style=file -i",


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/43

Note I tried the [edgedriver](https://www.npmjs.com/package/edgedriver) package on my Windows machine, but it wasn't able to download the WebDriver plugin. This (third-party) package contains a static list of Windows build numbers, and mine was not included (https://unpkg.com/edgedriver@4.17134.1/install.js). The latest [instructions ](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) from Microsoft just give a command to run from `cmd` instead of a download URL anyway, so I've just documented that users should follow those Microsoft instructions.