### PR TITLE
Add remote benchmarking support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Add support for Edge in Windows (`--browser=edge`).
 
+-   Add support for remote WebDriver with e.g.
+    `--browser=chrome@http://<remote-selenium-server>`. See `README` for more
+    details.
+
 -   Fix bug where no browser other than Chrome could be launched.
 
 -   Fix bug where process did not exit on most exceptions.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ confidence in them.
 - [*Automatically sample*](#auto-sampling) until we have enough precision to
   answer the question you are asking.
 
+
+- [*Remote control*](#remote-control) browsers running on different machines
+  using remote WebDriver.
+
 ## Measurement modes
 
 Tachometer currently supports two kinds of time interval measurements,
@@ -310,6 +314,73 @@ For Edge, follow the [Microsoft WebDriver
 installation](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
 documentation.
 
+## Remote control
+
+Tachometer can control and benchmark browsers running on remote machines by
+using the [Standalone Selenium
+Server](https://seleniumhq.github.io/docs/remote.html), which supports macOS,
+Windows, and Linux.
+
+This may be useful if you want to develop on one platform but benchmark on
+another, or if you want to use a dedicated benchmarking computer for better
+performance isolation.
+
+> Note you will need to know the IP address of both your local and remote
+> machine for the setup steps below. You can typically use `ipconfig` on
+> Windows, `ifconfig` on macOS, and `ip` on Linux to find these addresses.
+> You'll need to be able to initiate connections between these machines in both
+> directions, so if you encounter problems, it's possible that there is a
+> firewall or NAT preventing the connection.
+
+#### On the *remote* machine:
+
+1. Install a [Java Development Kit
+   (JDK)](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
+   if you don't already have one.
+
+
+2. Download the latest Standalone Selenium Server `.jar` file from
+   [seleniumhq.org](https://www.seleniumhq.org/download/).
+
+
+3. Download the driver plugins for the browsers you intend to remote control
+   from [seleniumhq.org](https://www.seleniumhq.org/download/). Note that if you
+   download a plugin archive file, the archive contents must be extracted and
+   placed either in the current working directory for the next command, or in a
+   directory that is included in your `$PATH` environment variable.
+
+
+4. Launch the Standalone Selenium Server.
+
+   ```bash
+   java -jar selenium-server-standalone-<version>.jar
+   ```
+
+#### On the *local* machine:
+
+ 1. Use the `--browser` flag or the `browser` config file property with syntax
+    `<browser>@<remote-url>` to tell tachometer the IP address or hostname of
+    the remote Standalone Selenium Server to launch the browser from. Note that
+    `4444` is the default port, and the `/wd/hub` URL suffix is required.
+
+    ```bash
+    --browser=chrome@http://my-remote-machine:4444/wd/hub
+    ```
+
+ 2. Use the `--host` flag to configure the network interface address that
+    tachometer's built-in static server will listen on (unless you are only
+    benchmarking external URLs that do not require the static server). By
+    default, for security, tachometer listens on `127.0.0.1` and will not be
+    accessible from the remote machine unless you change this to an IP address
+    or hostname that will be accessible from the remote machine.
+
+
+ 3. If needed, use the `--remote-accessible-host` flag to configure the URL that
+    the remote browser will use when making requests to your local tachometer
+    static server. By default this will match `--host`, but in some network
+    configurations it may need to be different (e.g. if the machines are
+    separated by a NAT).
+
 ## Config file
 
 Use the `--config` flag to control tachometer with a JSON configuration file.
@@ -413,3 +484,4 @@ Flag                      | Default     | Description
 `--horizon`               | `10%`       | The degrees of difference to try and resolve when auto-sampling ("N%" or "Nms", comma-delimited) ([details](#auto-sampling))
 `--timeout`               | `3`         | The maximum number of minutes to spend auto-sampling ([details](#auto-sampling))
 `--measure`               | `callback`  | Which time interval to measure (`callback`, `fcp`) ([details](#measurement-modes))
+`--remote-accessible-host`| matches `--host` | When using a browser over a remote WebDriver connection, the URL that those browsers should use to access the local tachometer server ([details](#remote-control))

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -42,7 +42,7 @@ export interface BrowserConfig {
   /** Whether to run in headless mode. */
   headless: boolean;
   /** A remote WebDriver server to launch the browser from. */
-  remoteUrl: string;
+  remoteUrl?: string;
 }
 
 /**
@@ -53,7 +53,7 @@ export interface BrowserConfig {
  *   chrome@<remote-selenium-server>
  */
 export function parseAndValidateBrowser(str: string): BrowserConfig {
-  let remoteUrl = '';
+  let remoteUrl;
   const at = str.indexOf('@');
   if (at !== -1) {
     remoteUrl = str.substring(at + 1);
@@ -78,7 +78,11 @@ export function parseAndValidateBrowser(str: string): BrowserConfig {
   if (headless === true && !headlessBrowsers.has(name)) {
     throw new Error(`Browser ${name} does not support headless mode.`);
   }
-  return {name, headless, remoteUrl};
+  const config: BrowserConfig = {name, headless};
+  if (remoteUrl !== undefined) {
+    config.remoteUrl = remoteUrl;
+  }
+  return config;
 }
 
 /**
@@ -91,7 +95,7 @@ export async function makeDriver(config: BrowserConfig):
   builder.forBrowser(webdriverName);
   builder.setChromeOptions(chromeOpts(config));
   builder.setFirefoxOptions(firefoxOpts(config));
-  if (config.remoteUrl !== '') {
+  if (config.remoteUrl !== undefined) {
     builder.usingServer(config.remoteUrl);
   } else if (config.name === 'edge') {
     // There appears to be bug where WebDriver doesn't automatically start or

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -392,7 +392,7 @@ function specUrl(
   }
   if (config.remoteAccessibleHost !== '') {
     const browser = parseAndValidateBrowser(spec.browser);
-    if (browser.remoteUrl !== '') {
+    if (browser.remoteUrl !== undefined) {
       return 'http://' + config.remoteAccessibleHost + ':' + server.port +
           spec.url.urlPath + spec.url.queryString;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -149,6 +149,7 @@ export interface Config {
   savePath: string;
   githubCheck?: CheckConfig;
   resolveBareModules: boolean;
+  remoteAccessibleHost: string;
 }
 
 export const defaultRoot = '.';
@@ -199,6 +200,7 @@ export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
     // These are only controlled by flags currently.
     mode: 'automatic',
     savePath: '',
+    remoteAccessibleHost: '',
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ interface Session {
 
 export class Server {
   readonly url: string;
+  readonly port: number;
   private readonly server: net.Server;
   private session: Session = {bytesSent: 0, userAgent: ''};
   private deferredResults = new Deferred<BenchmarkResponse>();
@@ -103,7 +104,8 @@ export class Server {
     if (address.family === 'IPv6') {
       host = `[${host}]`;
     }
-    this.url = `http://${host}:${address.port}`;
+    this.port = address.port;
+    this.url = `http://${host}:${this.port}`;
   }
 
   /**

--- a/src/test/browser_test.ts
+++ b/src/test/browser_test.ts
@@ -18,7 +18,6 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('chrome'), {
         name: 'chrome',
         headless: false,
-        remoteUrl: '',
       });
     });
 
@@ -26,7 +25,6 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('chrome-headless'), {
         name: 'chrome',
         headless: true,
-        remoteUrl: '',
       });
     });
 
@@ -34,7 +32,6 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('firefox'), {
         name: 'firefox',
         headless: false,
-        remoteUrl: '',
       });
     });
 
@@ -42,7 +39,6 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('firefox-headless'), {
         name: 'firefox',
         headless: true,
-        remoteUrl: '',
       });
     });
 
@@ -50,7 +46,6 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('safari'), {
         name: 'safari',
         headless: false,
-        remoteUrl: '',
       });
     });
 

--- a/src/test/browser_test.ts
+++ b/src/test/browser_test.ts
@@ -18,6 +18,7 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('chrome'), {
         name: 'chrome',
         headless: false,
+        remoteUrl: '',
       });
     });
 
@@ -25,6 +26,7 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('chrome-headless'), {
         name: 'chrome',
         headless: true,
+        remoteUrl: '',
       });
     });
 
@@ -32,6 +34,7 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('firefox'), {
         name: 'firefox',
         headless: false,
+        remoteUrl: '',
       });
     });
 
@@ -39,6 +42,7 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('firefox-headless'), {
         name: 'firefox',
         headless: true,
+        remoteUrl: '',
       });
     });
 
@@ -46,7 +50,25 @@ suite('browser', () => {
       assert.deepEqual(parseAndValidateBrowser('safari'), {
         name: 'safari',
         headless: false,
+        remoteUrl: '',
       });
+    });
+
+    test('chrome remote', () => {
+      assert.deepEqual(parseAndValidateBrowser('chrome@http://example.com'), {
+        name: 'chrome',
+        headless: false,
+        remoteUrl: 'http://example.com',
+      });
+    });
+
+    test('chrome-headless remote', () => {
+      assert.deepEqual(
+          parseAndValidateBrowser('chrome-headless@http://example.com'), {
+            name: 'chrome',
+            headless: true,
+            remoteUrl: 'http://example.com',
+          });
     });
 
     suite('errors', () => {
@@ -60,6 +82,18 @@ suite('browser', () => {
         assert.throws(
             () => parseAndValidateBrowser('safari-headless'),
             /browser safari does not support headless/i);
+      });
+
+      test('empty remote url', () => {
+        assert.throws(
+            () => parseAndValidateBrowser('chrome@'),
+            /expected url after "@"/i);
+      });
+
+      test('invalid remote url', () => {
+        assert.throws(
+            () => parseAndValidateBrowser('chrome@potato'),
+            /invalid remote url "potato"/i);
       });
     });
   });

--- a/src/test/config_test.ts
+++ b/src/test/config_test.ts
@@ -73,6 +73,7 @@ suite('config', () => {
         resolveBareModules: false,
         mode: 'automatic',
         savePath: '',
+        remoteAccessibleHost: '',
         benchmarks: [
           {
             name: 'remote',
@@ -128,6 +129,7 @@ suite('config', () => {
         resolveBareModules: true,
         mode: 'automatic',
         savePath: '',
+        remoteAccessibleHost: '',
         benchmarks: [
           {
             name: 'http://example.com?foo=bar',
@@ -188,6 +190,7 @@ suite('config', () => {
         resolveBareModules: true,
         mode: 'automatic',
         savePath: '',
+        remoteAccessibleHost: '',
         benchmarks: [
           {
             name: 'http://example.com',


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/48

You can now specify that a browser should be launched not from the local machine, but from a remote Selenium Standalone Server instance running on another machine.

I've tested this on my home network by running tachometer on my Mac, but launching Chrome and Edge on a remote Windows desktop.

See `READMD.md` for more details.