### PR TITLE
Add window.tachometerResult reporting style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
     `--browser=chrome@http://<remote-selenium-server>`. See `README` for more
     details.
 
+-   Add `--measure=global` mode, where the benchmark assigns an arbitrary
+    millisecond result to `window.tachometerResult`, and tachometer will poll
+    until it is found.
+
 -   Fix bug where no browser other than Chrome could be launched.
 
 -   Fix bug where process did not exit on most exceptions.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ confidence in them.
 
 ## Features
 
-- Measure your own [specific timings](#callback) with the `/bench.js` module, or
-  measure [First Contentful Paint](#first-contentful-paint-fcp) on any local or
-  remote URL.
+- Measure your own [specific timings](#callback) with the `/bench.js` module, by
+  setting the [window.tachometerResult](#global-result) global, or measure
+  [First Contentful Paint](#first-contentful-paint-fcp) on any local or remote
+  URL.
 
 
 - [*Compare benchmarks*](#multiple-benchmarks) by round-robin between two or
@@ -92,6 +93,22 @@ to **`callback`**, your page is responsible for calling the `start()` and
 `stop()` functions from the `/bench.js` module. This mode is appropriate for
 micro benchmarks, or any other kind of situation where you want full control
 over the beginning and end times.
+
+#### Global result
+
+When the `--measure` flag is set to `global`, then you can assign an arbitrary
+millisecond result to the `window.tachometerResult` global. In this mode,
+tachometer will poll until it finds a result assigned here.
+
+```javascript
+const start = performance.now();
+for (const i = 0; i < 1000; i++) { }
+window.tachometerResult = performance.now() - start;
+```
+
+This mode is appropriate when you need full control of the measured time, or
+when you can't use callback mode because you are not using tachometer's built-in
+server.
 
 #### First Contentful Paint (FCP)
 
@@ -483,5 +500,5 @@ Flag                      | Default     | Description
 `--sample-size` / `-n`    | `50`        | Minimum number of times to run each benchmark ([details](#sample-size)]
 `--horizon`               | `10%`       | The degrees of difference to try and resolve when auto-sampling ("N%" or "Nms", comma-delimited) ([details](#auto-sampling))
 `--timeout`               | `3`         | The maximum number of minutes to spend auto-sampling ([details](#auto-sampling))
-`--measure`               | `callback`  | Which time interval to measure (`callback`, `fcp`) ([details](#measurement-modes))
+`--measure`               | `callback`  | Which time interval to measure (`callback`, `global`, `fcp`) ([details](#measurement-modes))
 `--remote-accessible-host`| matches `--host` | When using a browser over a remote WebDriver connection, the URL that those browsers should use to access the local tachometer server ([details](#remote-control))

--- a/config.schema.json
+++ b/config.schema.json
@@ -21,7 +21,8 @@
                     "description": "Which time interval to measure.\n\nOptions:\n   - callback: bench.start() to bench.stop() (default for fully qualified\n     URLs.\n   - fcp: first contentful paint (default for local paths)",
                     "enum": [
                         "callback",
-                        "fcp"
+                        "fcp",
+                        "global"
                     ],
                     "type": "string"
                 },

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,9 @@ export interface NpmPackageJson {
 }
 
 /** The kinds of intervals we can measure. */
-export type Measurement = 'callback'|'fcp';
+export type Measurement = 'callback'|'fcp'|'global';
+
+export const measurements = new Set<Measurement>(['callback', 'fcp', 'global']);
 
 /** A specification of a benchmark to run. */
 export interface BenchmarkSpec {


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/60.

You can now use `--measure=global` and set `window.tachometerResult = <millis>` from the benchmark script. In this mode, tachometer will poll until it finds a result, similar to how we already grab first contentful paint time.

This serves a few goals:
1) It provides a way to set arbitrary results, for when `bench.start()` and `bench.stop()` don't give enough control (e.g. forwarding some timing data from another system).
2) It provides a way to report timing data from a server other than the built-in static server. (This is currently tricky to do, since you don't know the host/port of the server that is expecting to receive the result).
3) It will be compatible with IE, since IE doesn't support ES modules or `fetch`.

In a major release, I think we might want to just entirely drop the `bench.js` API, since this new style is universal, and it's simpler to just have one API.

cc @frankiefu @sorvell 