### PR TITLE
Fix bug where nodes_modules could be mounted at URL "//node_modules"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+-   Fix bug where the `node_modules` directory could sometimes be mounted at the
+    URL `//node_modules`, causing benchmarks to fail to load dependencies.
+
 -   Don't show URL query parameters in the result table when an alias was
     specified.
 

--- a/src/test/versions_test.ts
+++ b/src/test/versions_test.ts
@@ -29,143 +29,204 @@ const defaultBrowser = {
 };
 
 suite('versions', () => {
-  test('makeServerPlans', async () => {
-    const specs: BenchmarkSpec[] = [
-      // mybench running with two custom versions.
-      {
-        name: 'mybench',
-        url: {
-          kind: 'local',
-          urlPath: '/mylib/mybench/',
-          version: {
-            label: 'v1',
-            dependencyOverrides: {
-              mylib: '1.0.0',
+  suite('makeServerPlans', async () => {
+    test('various', async () => {
+      const specs: BenchmarkSpec[] = [
+        // mybench running with two custom versions.
+        {
+          name: 'mybench',
+          url: {
+            kind: 'local',
+            urlPath: '/mylib/mybench/',
+            version: {
+              label: 'v1',
+              dependencyOverrides: {
+                mylib: '1.0.0',
+              },
             },
+            queryString: '',
           },
-          queryString: '',
+          measurement: 'fcp',
+          browser: defaultBrowser,
         },
-        measurement: 'fcp',
-        browser: defaultBrowser,
-      },
-      {
-        name: 'mybench',
-        url: {
-          kind: 'local',
-          urlPath: '/mylib/mybench/',
-          version: {
-            label: 'v2',
-            dependencyOverrides: {
-              mylib: '2.0.0',
+        {
+          name: 'mybench',
+          url: {
+            kind: 'local',
+            urlPath: '/mylib/mybench/',
+            version: {
+              label: 'v2',
+              dependencyOverrides: {
+                mylib: '2.0.0',
+              },
             },
+            queryString: '',
           },
-          queryString: '',
+          measurement: 'fcp',
+          browser: defaultBrowser,
         },
-        measurement: 'fcp',
-        browser: defaultBrowser,
-      },
 
-      // mybench and other bench only need the default server.
-      {
-        name: 'mybench',
-        url: {
-          kind: 'local',
-          urlPath: '/mylib/mybench/',
-          queryString: '',
-        },
-        measurement: 'fcp',
-        browser: defaultBrowser,
-      },
-      {
-        name: 'otherbench',
-        url: {
-          kind: 'local',
-          urlPath: '/otherlib/otherbench/',
-          queryString: '',
-        },
-        measurement: 'fcp',
-        browser: defaultBrowser,
-      },
-
-      // A remote URL doesn't need a server.
-      {
-        name: 'http://example.com',
-        url: {
-          kind: 'remote',
-          url: 'http://example.com',
-        },
-        measurement: 'fcp',
-        browser: defaultBrowser,
-      },
-    ];
-
-    const tempDir = '/tmp';
-    const actual = await makeServerPlans(testData, tempDir, specs);
-
-    const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
-    const v2Hash = hashStrings(path.join(testData, 'mylib'), 'v2');
-
-    const expected: ServerPlan[] = [
-      {
-        specs: [specs[2], specs[3]],
-        npmInstalls: [],
-        mountPoints: [
-          {
-            diskPath: testData,
-            urlPath: '/',
+        // mybench and other bench only need the default server.
+        {
+          name: 'mybench',
+          url: {
+            kind: 'local',
+            urlPath: '/mylib/mybench/',
+            queryString: '',
           },
-        ],
-      },
+          measurement: 'fcp',
+          browser: defaultBrowser,
+        },
+        {
+          name: 'otherbench',
+          url: {
+            kind: 'local',
+            urlPath: '/otherlib/otherbench/',
+            queryString: '',
+          },
+          measurement: 'fcp',
+          browser: defaultBrowser,
+        },
 
-      {
-        specs: [specs[0]],
-        npmInstalls: [{
-          installDir: path.join(tempDir, v1Hash),
-          packageJson: {
-            private: true,
-            dependencies: {
-              mylib: '1.0.0',
-              otherlib: '0.0.0',
+        // A remote URL doesn't need a server.
+        {
+          name: 'http://example.com',
+          url: {
+            kind: 'remote',
+            url: 'http://example.com',
+          },
+          measurement: 'fcp',
+          browser: defaultBrowser,
+        },
+      ];
+
+      const tempDir = '/tmp';
+      const actual = await makeServerPlans(testData, tempDir, specs);
+
+      const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
+      const v2Hash = hashStrings(path.join(testData, 'mylib'), 'v2');
+
+      const expected: ServerPlan[] = [
+        {
+          specs: [specs[2], specs[3]],
+          npmInstalls: [],
+          mountPoints: [
+            {
+              diskPath: testData,
+              urlPath: '/',
             },
-          },
-        }],
-        mountPoints: [
-          {
-            diskPath: path.join(tempDir, v1Hash, 'node_modules'),
-            urlPath: '/mylib/node_modules',
-          },
-          {
-            diskPath: testData,
-            urlPath: '/',
-          },
-        ],
-      },
+          ],
+        },
 
-      {
-        specs: [specs[1]],
-        npmInstalls: [{
-          installDir: path.join(tempDir, v2Hash),
-          packageJson: {
-            private: true,
-            dependencies: {
-              mylib: '2.0.0',
-              otherlib: '0.0.0',
+        {
+          specs: [specs[0]],
+          npmInstalls: [{
+            installDir: path.join(tempDir, v1Hash),
+            packageJson: {
+              private: true,
+              dependencies: {
+                mylib: '1.0.0',
+                otherlib: '0.0.0',
+              },
             },
-          },
-        }],
-        mountPoints: [
-          {
-            diskPath: path.join(tempDir, v2Hash, 'node_modules'),
-            urlPath: '/mylib/node_modules',
-          },
-          {
-            diskPath: testData,
-            urlPath: '/',
-          },
-        ],
-      },
-    ];
+          }],
+          mountPoints: [
+            {
+              diskPath: path.join(tempDir, v1Hash, 'node_modules'),
+              urlPath: '/mylib/node_modules',
+            },
+            {
+              diskPath: testData,
+              urlPath: '/',
+            },
+          ],
+        },
 
-    assert.deepEqual(actual, expected);
+        {
+          specs: [specs[1]],
+          npmInstalls: [{
+            installDir: path.join(tempDir, v2Hash),
+            packageJson: {
+              private: true,
+              dependencies: {
+                mylib: '2.0.0',
+                otherlib: '0.0.0',
+              },
+            },
+          }],
+          mountPoints: [
+            {
+              diskPath: path.join(tempDir, v2Hash, 'node_modules'),
+              urlPath: '/mylib/node_modules',
+            },
+            {
+              diskPath: testData,
+              urlPath: '/',
+            },
+          ],
+        },
+      ];
+
+      assert.deepEqual(actual, expected);
+    });
+
+    /**
+     * Regression test for https://github.com/Polymer/tachometer/issues/82
+     * where the node_modules/ directory was being mounted at the
+     * "//node_modules" URL.
+     */
+    test('node_modules as direct child of root dir', async () => {
+      const specs: BenchmarkSpec[] = [
+        {
+          name: 'mybench',
+          url: {
+            kind: 'local',
+            urlPath: '/mybench/',
+            version: {
+              label: 'v1',
+              dependencyOverrides: {
+                mylib: '1.0.0',
+              },
+            },
+            queryString: '',
+          },
+          measurement: 'fcp',
+          browser: defaultBrowser,
+        },
+      ];
+
+      const tempDir = '/tmp';
+      const actual =
+          await makeServerPlans(path.join(testData, 'mylib'), tempDir, specs);
+
+      const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
+      const expected: ServerPlan[] = [
+        {
+          specs: [specs[0]],
+          npmInstalls: [{
+            installDir: path.join(tempDir, v1Hash),
+            packageJson: {
+              private: true,
+              dependencies: {
+                mylib: '1.0.0',
+                otherlib: '0.0.0',
+              },
+            },
+          }],
+          mountPoints: [
+            {
+              diskPath: path.join(tempDir, v1Hash, 'node_modules'),
+              urlPath: '/node_modules',
+            },
+            {
+              diskPath: path.join(testData, 'mylib'),
+              urlPath: '/',
+            },
+          ],
+        },
+      ];
+
+      assert.deepEqual(actual, expected);
+    });
   });
 });

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -135,7 +135,11 @@ export async function makeServerPlans(
       }],
       mountPoints: [
         {
-          urlPath: `/${path.relative(benchmarkRoot, packageDir)}/node_modules`,
+          urlPath: path.posix.join(
+              '/',
+              path.relative(benchmarkRoot, packageDir)
+                  .replace(path.win32.sep, '/'),
+              'node_modules'),
           diskPath: path.join(installDir, 'node_modules'),
         },
         {


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/82

Recommend viewing with ?w=1 because the test didn't change as much as it looks.