### PR TITLE
Retry and eventually fail after timeouts, instead of ignoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+-   Fix bug where timeouts in measuring the `window.tachometerResult` global
+    (e.g. when the server is down) could cause a crash with `Reduce of empty
+    array with no initial value`
+    ([#86](https://github.com/Polymer/tachometer/issues/86)).
+
 -   When using custom package versions, the temporary NPM install directories
     will now be re-used less aggressively across runs of tachometer. If any of
     the specified dependency versions have changed, or if the version of


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/86

Before, we simply ignored timeouts, allowing the sample size to fall by one each time. In the case that all samples timed out, this caused a hard crash in code that assumed there would be at least one measurement.

Now, we retry timeouts 3 times and abort after the final attempt.

This is what will now happen if your server is down:

<img width="658" alt="Screen Shot 2019-07-11 at 10 55 35 AM" src="https://user-images.githubusercontent.com/48894/61073513-74cfaf80-a3ca-11e9-8ea8-75e1840151a8.png">