### PR TITLE
Fix bug where flags were ignored when using a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+-   Fix bug where the `--manual`, `--csv-file`, and other flags were ignored
+    if a config file was in use.
 
 ## [0.4.11] 2019-08-13
 

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -217,7 +217,8 @@ interface ConfigFilePackageVersion {
  * Validate the given JSON object parsed from a config file, and expand it into
  * a fully specified configuration.
  */
-export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
+export async function parseConfigFile(parsedJson: unknown):
+    Promise<Partial<Config>> {
   const schema = require('../config.schema.json');
   const result =
       jsonschema.validate(parsedJson, schema, {propertyName: 'config'});
@@ -235,22 +236,13 @@ export async function parseConfigFile(parsedJson: unknown): Promise<Config> {
 
   return {
     root,
-    sampleSize: validated.sampleSize !== undefined ? validated.sampleSize :
-                                                     defaults.sampleSize,
-    timeout: validated.timeout !== undefined ? validated.timeout :
-                                               defaults.timeout,
-    horizons: parseHorizons(validated.horizons || [...defaults.horizons]),
+    sampleSize: validated.sampleSize,
+    timeout: validated.timeout,
+    horizons: validated.horizons !== undefined ?
+        parseHorizons(validated.horizons) :
+        undefined,
     benchmarks,
-    resolveBareModules: validated.resolveBareModules === undefined ?
-        true :
-        validated.resolveBareModules,
-
-    // These are only controlled by flags currently.
-    mode: 'automatic',
-    savePath: '',
-    remoteAccessibleHost: '',
-    forceCleanNpmInstall: false,
-    csvFile: '',
+    resolveBareModules: validated.resolveBareModules,
   };
 }
 

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -19,6 +19,9 @@ export const browserName: BrowserName = 'chrome';
 export const sampleSize = 50;
 export const timeout = 3;
 export const horizons = ['0%'] as const ;
+export const mode = 'automatic';
+export const resolveBareModules = true;
+export const forceCleanNpmInstall = false;
 
 export function measurement(url: LocalUrl|RemoteUrl): Measurement {
   if (url.kind === 'remote') {

--- a/src/test/config_test.ts
+++ b/src/test/config_test.ts
@@ -109,6 +109,90 @@ suite('makeConfig', function() {
     };
     await checkConfig(argv, expected);
   });
+
+  test('config file with --manual', async () => {
+    const argv = ['--config=random-global.json', '--manual'];
+    const expected: Config = {
+      mode: 'manual',
+
+      sampleSize: 50,
+      timeout: 3,
+      root: '.',
+      resolveBareModules: true,
+      forceCleanNpmInstall: false,
+      horizons: {absolute: [], relative: [0]},
+      remoteAccessibleHost: '',
+      savePath: '',
+      csvFile: '',
+      githubCheck: undefined,
+      benchmarks: [
+        {
+          browser: {
+            headless: false,
+            name: 'chrome',
+            windowSize: {
+              height: 768,
+              width: 1024,
+            },
+          },
+          measurement: 'callback',
+          // TODO(aomarks) Why does this have a forward-slash?
+          name: '/random-global.html',
+          url: {
+            kind: 'local',
+            queryString: '',
+            urlPath: '/random-global.html',
+          },
+        },
+      ],
+    };
+    await checkConfig(argv, expected);
+  });
+
+  test('config file with output files and force clean install', async () => {
+    const argv = [
+      '--config=random-global.json',
+      '--csv-file=out.csv',
+      '--save=out.json',
+      '--force-clean-npm-install',
+    ];
+    const expected: Config = {
+      mode: 'automatic',
+      csvFile: 'out.csv',
+      savePath: 'out.json',
+      forceCleanNpmInstall: true,
+
+      sampleSize: 50,
+      timeout: 3,
+      root: '.',
+      resolveBareModules: true,
+      horizons: {absolute: [], relative: [0]},
+      remoteAccessibleHost: '',
+      // TODO(aomarks) Be consistent about undefined vs unset.
+      githubCheck: undefined,
+      benchmarks: [
+        {
+          browser: {
+            headless: false,
+            name: 'chrome',
+            windowSize: {
+              height: 768,
+              width: 1024,
+            },
+          },
+          measurement: 'callback',
+          // TODO(aomarks) Why does this have a forward-slash?
+          name: '/random-global.html',
+          url: {
+            kind: 'local',
+            queryString: '',
+            urlPath: '/random-global.html',
+          },
+        },
+      ],
+    };
+    await checkConfig(argv, expected);
+  });
 });
 
 suite('parseHorizons', function() {

--- a/src/test/configfile_test.ts
+++ b/src/test/configfile_test.ts
@@ -74,7 +74,7 @@ suite('config', () => {
           },
         ],
       };
-      const expected: Config = {
+      const expected: Partial<Config> = {
         root: '.',
         sampleSize: 52,
         timeout: 7,
@@ -83,11 +83,6 @@ suite('config', () => {
           relative: [-0.02, 0.02, 0.03],
         },
         resolveBareModules: false,
-        mode: 'automatic',
-        savePath: '',
-        remoteAccessibleHost: '',
-        forceCleanNpmInstall: false,
-        csvFile: '',
         benchmarks: [
           {
             name: 'remote',
@@ -135,20 +130,12 @@ suite('config', () => {
           },
         ],
       };
-      const expected: Config = {
+      const expected: Partial<Config> = {
         root: '.',
-        sampleSize: 50,
-        timeout: 3,
-        horizons: {
-          absolute: [],
-          relative: [0],
-        },
-        resolveBareModules: true,
-        mode: 'automatic',
-        savePath: '',
-        remoteAccessibleHost: '',
-        forceCleanNpmInstall: false,
-        csvFile: '',
+        sampleSize: undefined,
+        timeout: undefined,
+        horizons: undefined,
+        resolveBareModules: undefined,
         benchmarks: [
           {
             name: 'http://example.com?foo=bar',
@@ -198,20 +185,12 @@ suite('config', () => {
           ],
         }],
       };
-      const expected: Config = {
+      const expected: Partial<Config> = {
         root: '.',
-        sampleSize: 50,
-        timeout: 3,
-        horizons: {
-          absolute: [],
-          relative: [0],
-        },
-        resolveBareModules: true,
-        mode: 'automatic',
-        savePath: '',
-        remoteAccessibleHost: '',
-        forceCleanNpmInstall: false,
-        csvFile: '',
+        sampleSize: undefined,
+        timeout: undefined,
+        horizons: undefined,
+        resolveBareModules: undefined,
         benchmarks: [
           {
             name: 'http://example.com',

--- a/src/test/test_helpers.ts
+++ b/src/test/test_helpers.ts
@@ -10,6 +10,8 @@
  */
 
 import * as path from 'path';
+
+import {applyDefaults} from '../config';
 import {ConfigFile, parseConfigFile} from '../configfile';
 import {computeDifferences, ResultStatsWithDifferences, summaryStats} from '../stats';
 
@@ -37,7 +39,7 @@ const userAgents = new Map([
  */
 export async function fakeResults(configFile: ConfigFile):
     Promise<ResultStatsWithDifferences[]> {
-  const config = await parseConfigFile(configFile);
+  const config = applyDefaults(await parseConfigFile(configFile));
   const results = [];
   for (let i = 0; i < config.benchmarks.length; i++) {
     const {name, url, browser} = config.benchmarks[i];


### PR DESCRIPTION
Affected `--manual`, `--csv-file`, `--save`, `--force-clean-npm-install`, and `--remote-accessible-host`.

Fixes https://github.com/Polymer/tachometer/issues/116
Fixes https://github.com/Polymer/tachometer/issues/119