### PR TITLE
Add support for globalMeasurementExpression. Fixes #130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
+### Added
+
+-   Added a `globalMeasurementExpression` option for overriding the default
+    global measurement of `window.tachometerResult` to an arbitrary expression.
+
 ## [0.4.13] 2019-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--   Added a `globalMeasurementExpression` option for overriding the default
+-   Added a `measurementExpression` option for overriding the default
     global measurement of `window.tachometerResult` to an arbitrary expression.
 
 ## [0.4.13] 2019-09-12

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ confidence in them.
 ## Features
 
 - Measure your own [specific timings](#callback) with the `/bench.js` module, by
-  setting the [window.tachometerResult](#global-result) global, or measure
-  [First Contentful Paint](#first-contentful-paint-fcp) on any local or remote
+  setting the [window.tachometerResult](#global-result) global (or by polling an
+  arbitrary JS expression), or measure [First Contentful Paint](#first-contentful-paint-fcp) on any local or remote
   URL.
 
 
@@ -83,7 +83,7 @@ confidence in them.
 
 ## Measurement modes
 
-Tachometer currently supports two kinds of time interval measurements,
+Tachometer currently supports three kinds of time interval measurements,
 controlled with the `--measure` flag.
 
 #### Callback
@@ -109,6 +109,12 @@ window.tachometerResult = performance.now() - start;
 This mode is appropriate when you need full control of the measured time, or
 when you can't use callback mode because you are not using tachometer's built-in
 server.
+
+Alternatively, to poll an arbitrary JS expression in `global` measurement mode
+(rather than `window.tachometerResult`), set `--measurement-expression` to the
+JS expression to poll.  This option is useful for scenarios where you cannot
+easily modify the code under test to assign to `window.tachometerResult` but
+are otherwise able to extract a measurement from the page using JavaScript.
 
 #### First Contentful Paint (FCP)
 
@@ -585,6 +591,7 @@ Flag                    -  | Default     | Description
 `--horizon`                | `10%`       | The degrees of difference to try and resolve when auto-sampling ("N%" or "Nms", comma-delimited) ([details](#auto-sampling))
 `--timeout`                | `3`         | The maximum number of minutes to spend auto-sampling ([details](#auto-sampling))
 `--measure`                | `callback`  | Which time interval to measure (`callback`, `global`, `fcp`) ([details](#measurement-modes))
+`--measurement-expression` | `window.tachometerResult`  | JS expression to poll for on page to retrieve measurement result when `measure` setting is set to `global`
 `--remote-accessible-host` | matches `--host` | When using a browser over a remote WebDriver connection, the URL that those browsers should use to access the local tachometer server ([details](#remote-control))
 `--npm-install-dir`        | system temp dir | Where to install custom package versions. ([details](#swap-npm-dependencies))
 `--force-clean-npm-install`| `false`     | Always do a from-scratch NPM install when using custom package versions. ([details](#swap-npm-dependencies))

--- a/config.schema.json
+++ b/config.schema.json
@@ -82,17 +82,17 @@
                     },
                     "type": "array"
                 },
-                "globalMeasurementExpression": {
-                    "description": "Expression to use to retrieve global result.  Defaults to\n`window.tachometerResult`.",
-                    "type": "string"
-                },
                 "measurement": {
-                    "description": "Which time interval to measure.\n\nOptions:\n   - callback: bench.start() to bench.stop() (default for fully qualified\n     URLs.\n   - fcp: first contentful paint (default for local paths)\n   - global: result returned from window.tachometerResult (or custom\n       expression set via globalMeasurementExpression)",
+                    "description": "Which time interval to measure.\n\nOptions:\n   - callback: bench.start() to bench.stop() (default for fully qualified\n     URLs.\n   - fcp: first contentful paint (default for local paths)\n   - global: result returned from window.tachometerResult (or custom\n       expression set via measurementExpression)",
                     "enum": [
                         "callback",
                         "fcp",
                         "global"
                     ],
+                    "type": "string"
+                },
+                "measurementExpression": {
+                    "description": "Expression to use to retrieve global result.  Defaults to\n`window.tachometerResult`.",
                     "type": "string"
                 },
                 "name": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -82,8 +82,12 @@
                     },
                     "type": "array"
                 },
+                "globalMeasurementExpression": {
+                    "description": "Expression to use to retrieve global result.  Defaults to\n`window.tachometerResult`.",
+                    "type": "string"
+                },
                 "measurement": {
-                    "description": "Which time interval to measure.\n\nOptions:\n   - callback: bench.start() to bench.stop() (default for fully qualified\n     URLs.\n   - fcp: first contentful paint (default for local paths)",
+                    "description": "Which time interval to measure.\n\nOptions:\n   - callback: bench.start() to bench.stop() (default for fully qualified\n     URLs.\n   - fcp: first contentful paint (default for local paths)\n   - global: result returned from window.tachometerResult (or custom\n       expression set via globalMeasurementExpression)",
                     "enum": [
                         "callback",
                         "fcp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,9 +725,9 @@
       "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "chromedriver": {
-      "version": "76.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.1.tgz",
-      "integrity": "sha512-+8BCemJLKPF2w/UpzA1uNgLWQrg1IgIO4ZYcsAjYYgqD8zUcvQ+RfwA/0TR1Zwv9Mkd8fdzTe21eZ2FyZ83DAg==",
+      "version": "78.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.1.tgz",
+      "integrity": "sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==",
       "requires": {
         "del": "^4.1.1",
         "extract-zip": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/ua-parser-js": "^0.7.32",
     "ansi-escape-sequences": "^4.0.1",
     "chai-as-promised": "^7.1.1",
-    "chromedriver": ">75.0.0",
+    "chromedriver": "^78.0.1",
     "command-line-args": "^5.0.2",
     "command-line-usage": "^6.0.1",
     "csv-stringify": "^5.3.0",

--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -104,7 +104,7 @@ export async function automaticMode(
       if (spec.measurement === 'fcp') {
         millis = await pollForFirstContentfulPaint(driver);
       } else if (spec.measurement === 'global') {
-        millis = await pollForGlobalResult(driver);
+        millis = await pollForGlobalResult(driver, spec.globalMeasurementExpression || '');
       } else {  // bench.start() and bench.stop() callback
         if (server === undefined) {
           throw new Error('Internal error: no server for spec');
@@ -130,6 +130,8 @@ export async function automaticMode(
       console.log(
           `\n\nFailed ${attempt}/${maxAttempts} times ` +
           `to get a ${spec.measurement} measurement ` +
+          (spec.measurement === 'global' ?
+            `(from '${spec.globalMeasurementExpression}') ` : '') +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }
 
@@ -138,7 +140,9 @@ export async function automaticMode(
       throw new Error(
           `\n\nFailed ${maxAttempts}/${maxAttempts} times ` +
           `to get a ${spec.measurement} measurement ` +
-          `in ${spec.browser.name} from ${url}. Aborting.\n`);
+          (spec.measurement === 'global' ?
+            `(from '${spec.globalMeasurementExpression}') ` : '') +
+          `in ${spec.browser.name} from ${url}. Retrying.`);
     }
 
     return {

--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -104,8 +104,8 @@ export async function automaticMode(
       if (spec.measurement === 'fcp') {
         millis = await pollForFirstContentfulPaint(driver);
       } else if (spec.measurement === 'global') {
-        millis = await pollForGlobalResult(
-            driver, spec.globalMeasurementExpression || '');
+        millis =
+            await pollForGlobalResult(driver, spec.measurementExpression || '');
       } else {  // bench.start() and bench.stop() callback
         if (server === undefined) {
           throw new Error('Internal error: no server for spec');
@@ -132,7 +132,7 @@ export async function automaticMode(
           `\n\nFailed ${attempt}/${maxAttempts} times ` +
           `to get a ${spec.measurement} measurement ` +
           (spec.measurement === 'global' ?
-               `(from '${spec.globalMeasurementExpression}') ` :
+               `(from '${spec.measurementExpression}') ` :
                '') +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }
@@ -143,7 +143,7 @@ export async function automaticMode(
           `\n\nFailed ${maxAttempts}/${maxAttempts} times ` +
           `to get a ${spec.measurement} measurement ` +
           (spec.measurement === 'global' ?
-               `(from '${spec.globalMeasurementExpression}') ` :
+               `(from '${spec.measurementExpression}') ` :
                '') +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }

--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -104,7 +104,8 @@ export async function automaticMode(
       if (spec.measurement === 'fcp') {
         millis = await pollForFirstContentfulPaint(driver);
       } else if (spec.measurement === 'global') {
-        millis = await pollForGlobalResult(driver, spec.globalMeasurementExpression || '');
+        millis = await pollForGlobalResult(
+            driver, spec.globalMeasurementExpression || '');
       } else {  // bench.start() and bench.stop() callback
         if (server === undefined) {
           throw new Error('Internal error: no server for spec');
@@ -131,7 +132,8 @@ export async function automaticMode(
           `\n\nFailed ${attempt}/${maxAttempts} times ` +
           `to get a ${spec.measurement} measurement ` +
           (spec.measurement === 'global' ?
-            `(from '${spec.globalMeasurementExpression}') ` : '') +
+               `(from '${spec.globalMeasurementExpression}') ` :
+               '') +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }
 
@@ -141,7 +143,8 @@ export async function automaticMode(
           `\n\nFailed ${maxAttempts}/${maxAttempts} times ` +
           `to get a ${spec.measurement} measurement ` +
           (spec.measurement === 'global' ?
-            `(from '${spec.globalMeasurementExpression}') ` : '') +
+               `(from '${spec.globalMeasurementExpression}') ` :
+               '') +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -255,7 +255,9 @@ export async function pollForFirstContentfulPaint(driver: webdriver.WebDriver):
  * after 10 seconds. Throws if a value was found, but it was not a number, or it
  * was a negative number.
  */
-export async function pollForGlobalResult(driver: webdriver.WebDriver):
+export async function pollForGlobalResult(
+  driver: webdriver.WebDriver,
+  expression: string):
     Promise<number|undefined> {
   // Both here and for FCP above, we could automatically tune the poll time
   // after we get our first result, so that when the script is fast we spend
@@ -263,16 +265,15 @@ export async function pollForGlobalResult(driver: webdriver.WebDriver):
   // less frequently.
   for (let waited = 0; waited <= 10000; waited += 50) {
     await wait(50);
-    const result = await driver.executeScript(
-                       'return window.tachometerResult;') as unknown;
+    const result = await driver.executeScript(`return (${expression});`) as unknown;
     if (result !== undefined && result !== null) {
       if (typeof result !== 'number') {
         throw new Error(
-            `window.tachometerResult was type ` +
+            `'${expression}' was type ` +
             `${typeof result}, expected number.`);
       }
       if (result < 0) {
-        throw new Error(`window.tachometerResult was negative: ${result}`);
+        throw new Error(`'${expression}' was negative: ${result}`);
       }
       return result;
     }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -256,16 +256,16 @@ export async function pollForFirstContentfulPaint(driver: webdriver.WebDriver):
  * was a negative number.
  */
 export async function pollForGlobalResult(
-  driver: webdriver.WebDriver,
-  expression: string):
-    Promise<number|undefined> {
+    driver: webdriver.WebDriver,
+    expression: string): Promise<number|undefined> {
   // Both here and for FCP above, we could automatically tune the poll time
   // after we get our first result, so that when the script is fast we spend
   // less time waiting, and so that when the script is slow we interfere it
   // less frequently.
   for (let waited = 0; waited <= 10000; waited += 50) {
     await wait(50);
-    const result = await driver.executeScript(`return (${expression});`) as unknown;
+    const result =
+        await driver.executeScript(`return (${expression});`) as unknown;
     if (result !== undefined && result !== null) {
       if (typeof result !== 'number') {
         throw new Error(

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,9 +176,7 @@ export async function urlFromLocalPath(
 
   const kind = await fileKind(diskPath);
   if (kind === undefined) {
-    const error = new Error(`No such file or directory: ${diskPath}`);
-    console.log(error.stack);
-    throw error;
+    throw new Error(`No such file or directory: ${diskPath}`);
   }
 
   // TODO Test on Windows.

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,7 +176,9 @@ export async function urlFromLocalPath(
 
   const kind = await fileKind(diskPath);
   if (kind === undefined) {
-    throw new Error(`No such file or directory: ${diskPath}`);
+    const error = new Error(`No such file or directory: ${diskPath}`);
+    console.log(error.stack);
+    throw error;
   }
 
   // TODO Test on Windows.

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -310,7 +310,8 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
   if (benchmark.measurement !== undefined) {
     spec.measurement = benchmark.measurement;
   }
-  if (benchmark.globalMeasurementExpression !== undefined) {
+  if (spec.measurement === 'global' &&
+      benchmark.globalMeasurementExpression !== undefined) {
     spec.globalMeasurementExpression = benchmark.globalMeasurementExpression;
   }
 
@@ -392,7 +393,7 @@ function applyExpansions(bench: ConfigFileBenchmark): ConfigFileBenchmark[] {
 
 function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   const url = partialSpec.url;
-  let {name, measurement, globalMeasurementExpression, browser} = partialSpec;
+  let {name, measurement, browser} = partialSpec;
   if (url === undefined) {
     // Note we can't validate this with jsonschema, because we only need to
     // ensure we have a URL after recursive expansion; so at any given level
@@ -421,10 +422,12 @@ function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   if (measurement === undefined) {
     measurement = defaults.measurement(url);
   }
-  if (globalMeasurementExpression === undefined) {
-    globalMeasurementExpression = defaults.globalMeasurementExpression;
+  const spec: BenchmarkSpec = {name, url, browser, measurement};
+  if (measurement === 'global' &&
+      partialSpec.globalMeasurementExpression === undefined) {
+    spec.globalMeasurementExpression = defaults.globalMeasurementExpression;
   }
-  return {name, url, browser, measurement, globalMeasurementExpression};
+  return spec;
 }
 
 export async function writeBackSchemaIfNeeded(

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -106,7 +106,7 @@ interface ConfigFileBenchmark {
    *     URLs.
    *   - fcp: first contentful paint (default for local paths)
    *   - global: result returned from window.tachometerResult (or custom
-   *       expression set via globalMeasurementExpression)
+   *       expression set via measurementExpression)
    */
   measurement?: Measurement;
 
@@ -114,7 +114,7 @@ interface ConfigFileBenchmark {
    * Expression to use to retrieve global result.  Defaults to
    * `window.tachometerResult`.
    */
-  globalMeasurementExpression?: string;
+  measurementExpression?: string;
 
   /**
    * Optional NPM dependency overrides to apply and install. Only supported with
@@ -311,8 +311,8 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
     spec.measurement = benchmark.measurement;
   }
   if (spec.measurement === 'global' &&
-      benchmark.globalMeasurementExpression !== undefined) {
-    spec.globalMeasurementExpression = benchmark.globalMeasurementExpression;
+      benchmark.measurementExpression !== undefined) {
+    spec.measurementExpression = benchmark.measurementExpression;
   }
 
   const url = benchmark.url;
@@ -424,8 +424,8 @@ function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   }
   const spec: BenchmarkSpec = {name, url, browser, measurement};
   if (measurement === 'global' &&
-      partialSpec.globalMeasurementExpression === undefined) {
-    spec.globalMeasurementExpression = defaults.globalMeasurementExpression;
+      partialSpec.measurementExpression === undefined) {
+    spec.measurementExpression = defaults.measurementExpression;
   }
   return spec;
 }

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -105,8 +105,16 @@ interface ConfigFileBenchmark {
    *   - callback: bench.start() to bench.stop() (default for fully qualified
    *     URLs.
    *   - fcp: first contentful paint (default for local paths)
+   *   - global: result returned from window.tachometerResult (or custom
+   *       expression set via globalMeasurementExpression)
    */
   measurement?: Measurement;
+
+  /**
+   * Expression to use to retrieve global result.  Defaults to
+   * `window.tachometerResult`.
+   */
+  globalMeasurementExpression?: string;
 
   /**
    * Optional NPM dependency overrides to apply and install. Only supported with
@@ -302,6 +310,9 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
   if (benchmark.measurement !== undefined) {
     spec.measurement = benchmark.measurement;
   }
+  if (benchmark.globalMeasurementExpression !== undefined) {
+    spec.globalMeasurementExpression = benchmark.globalMeasurementExpression;
+  }
 
   const url = benchmark.url;
   if (url !== undefined) {
@@ -381,7 +392,7 @@ function applyExpansions(bench: ConfigFileBenchmark): ConfigFileBenchmark[] {
 
 function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   const url = partialSpec.url;
-  let {name, measurement, browser} = partialSpec;
+  let {name, measurement, globalMeasurementExpression, browser} = partialSpec;
   if (url === undefined) {
     // Note we can't validate this with jsonschema, because we only need to
     // ensure we have a URL after recursive expansion; so at any given level
@@ -410,7 +421,10 @@ function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   if (measurement === undefined) {
     measurement = defaults.measurement(url);
   }
-  return {name, url, browser, measurement};
+  if (globalMeasurementExpression === undefined) {
+    globalMeasurementExpression = defaults.globalMeasurementExpression;
+  }
+  return {name, url, browser, measurement, globalMeasurementExpression};
 }
 
 export async function writeBackSchemaIfNeeded(

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,6 +22,7 @@ export const horizons = ['0%'] as const ;
 export const mode = 'automatic';
 export const resolveBareModules = true;
 export const forceCleanNpmInstall = false;
+export const globalMeasurementExpression = 'window.tachometerResult';
 
 export function measurement(url: LocalUrl|RemoteUrl): Measurement {
   if (url.kind === 'remote') {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,7 +22,7 @@ export const horizons = ['0%'] as const ;
 export const mode = 'automatic';
 export const resolveBareModules = true;
 export const forceCleanNpmInstall = false;
-export const globalMeasurementExpression = 'window.tachometerResult';
+export const measurementExpression = 'window.tachometerResult';
 
 export function measurement(url: LocalUrl|RemoteUrl): Measurement {
   if (url.kind === 'remote') {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -150,6 +150,14 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
     },
   },
   {
+    name: 'global-measurement-expression',
+    description:
+        'Javascript expression to poll from page to retrieve global\n' +
+        'result. Only valid when --measure=global.',
+    type: String,
+    defaultValue: defaults.globalMeasurementExpression
+  },
+  {
     name: 'horizon',
     description:
         'The degrees of difference to try and resolve when auto-sampling ' +
@@ -203,7 +211,7 @@ export interface Opts {
   manual: boolean;
   save: string;
   measure: Measurement|undefined;
-  globalMeasurementExpression: string|undefined;
+  'global-measurement-expression': string|undefined;
   horizon: string|undefined;
   timeout: number|undefined;
   'github-check': string;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -150,12 +150,12 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
     },
   },
   {
-    name: 'global-measurement-expression',
+    name: 'measurement-expression',
     description:
         'Javascript expression to poll from page to retrieve global\n' +
         'result. Only valid when --measure=global.',
     type: String,
-    defaultValue: defaults.globalMeasurementExpression
+    defaultValue: defaults.measurementExpression
   },
   {
     name: 'horizon',
@@ -211,7 +211,7 @@ export interface Opts {
   manual: boolean;
   save: string;
   measure: Measurement|undefined;
-  'global-measurement-expression': string|undefined;
+  'measurement-expression': string|undefined;
   horizon: string|undefined;
   timeout: number|undefined;
   'github-check': string;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -203,6 +203,7 @@ export interface Opts {
   manual: boolean;
   save: string;
   measure: Measurement|undefined;
+  globalMeasurementExpression: string|undefined;
   horizon: string|undefined;
   timeout: number|undefined;
   'github-check': string;

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -81,11 +81,15 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
       };
       const measurement =
           opts.measure !== undefined ? opts.measure : defaults.measurement(url);
+      const globalMeasurementExpression =
+        opts.globalMeasurementExpression !== undefined ?
+        opts.globalMeasurementExpression : defaults.globalMeasurementExpression;
       for (const browser of browsers) {
         specs.push({
           name: arg.alias || arg.url,
           browser,
           measurement,
+          globalMeasurementExpression,
           url,
         });
       }
@@ -109,10 +113,14 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
           const measurement = opts.measure !== undefined ?
               opts.measure :
               defaults.measurement(url);
+          const globalMeasurementExpression =
+            opts.globalMeasurementExpression !== undefined ?
+            opts.globalMeasurementExpression : defaults.globalMeasurementExpression;
           specs.push({
             name,
             browser,
             measurement,
+            globalMeasurementExpression,
             url,
           });
         }

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -81,10 +81,10 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
       };
       const measurement =
           opts.measure !== undefined ? opts.measure : defaults.measurement(url);
-      const globalMeasurementExpression = measurement === 'global' ?
-          (opts['global-measurement-expression'] !== undefined ?
-               opts['global-measurement-expression'] :
-               defaults.globalMeasurementExpression) :
+      const measurementExpression = measurement === 'global' ?
+          (opts['measurement-expression'] !== undefined ?
+               opts['measurement-expression'] :
+               defaults.measurementExpression) :
           undefined;
       for (const browser of browsers) {
         const spec: BenchmarkSpec = {
@@ -93,8 +93,8 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
           measurement,
           url,
         };
-        if (globalMeasurementExpression) {
-          spec.globalMeasurementExpression = globalMeasurementExpression;
+        if (measurementExpression) {
+          spec.measurementExpression = measurementExpression;
         }
         specs.push(spec);
       }
@@ -118,10 +118,10 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
           const measurement = opts.measure !== undefined ?
               opts.measure :
               defaults.measurement(url);
-          const globalMeasurementExpression = measurement === 'global' ?
-              (opts['global-measurement-expression'] !== undefined ?
-                   opts['global-measurement-expression'] :
-                   defaults.globalMeasurementExpression) :
+          const measurementExpression = measurement === 'global' ?
+              (opts['measurement-expression'] !== undefined ?
+                   opts['measurement-expression'] :
+                   defaults.measurementExpression) :
               undefined;
           const spec: BenchmarkSpec = {
             name,
@@ -129,8 +129,8 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
             measurement,
             url,
           };
-          if (globalMeasurementExpression) {
-            spec.globalMeasurementExpression = globalMeasurementExpression;
+          if (measurementExpression) {
+            spec.measurementExpression = measurementExpression;
           }
           specs.push(spec);
         }

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -81,17 +81,22 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
       };
       const measurement =
           opts.measure !== undefined ? opts.measure : defaults.measurement(url);
-      const globalMeasurementExpression =
-        opts.globalMeasurementExpression !== undefined ?
-        opts.globalMeasurementExpression : defaults.globalMeasurementExpression;
+      const globalMeasurementExpression = measurement === 'global' ?
+          (opts['global-measurement-expression'] !== undefined ?
+               opts['global-measurement-expression'] :
+               defaults.globalMeasurementExpression) :
+          undefined;
       for (const browser of browsers) {
-        specs.push({
+        const spec: BenchmarkSpec = {
           name: arg.alias || arg.url,
           browser,
           measurement,
-          globalMeasurementExpression,
           url,
-        });
+        };
+        if (globalMeasurementExpression) {
+          spec.globalMeasurementExpression = globalMeasurementExpression;
+        }
+        specs.push(spec);
       }
 
     } else {
@@ -113,16 +118,21 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
           const measurement = opts.measure !== undefined ?
               opts.measure :
               defaults.measurement(url);
-          const globalMeasurementExpression =
-            opts.globalMeasurementExpression !== undefined ?
-            opts.globalMeasurementExpression : defaults.globalMeasurementExpression;
-          specs.push({
+          const globalMeasurementExpression = measurement === 'global' ?
+              (opts['global-measurement-expression'] !== undefined ?
+                   opts['global-measurement-expression'] :
+                   defaults.globalMeasurementExpression) :
+              undefined;
+          const spec: BenchmarkSpec = {
             name,
             browser,
             measurement,
-            globalMeasurementExpression,
             url,
-          });
+          };
+          if (globalMeasurementExpression) {
+            spec.globalMeasurementExpression = globalMeasurementExpression;
+          }
+          specs.push(spec);
         }
       }
     }

--- a/src/test/data/random-global.html
+++ b/src/test/data/random-global.html
@@ -14,7 +14,13 @@ the range determined by the "min" and "max" URL search parameters.
       const params = new URL(document.location).searchParams;
       const min = Number(params.get('min'));
       const max = Number(params.get('max'));
-      window.tachometerResult = Math.random() * (max - min) + min;
+      const customResult = params.has('customResult');
+      const result = Math.random() * (max - min) + min;
+      if (customResult) {
+        window.customResult = result;
+      } else {
+        window.tachometerResult = result;
+      }
     </script>
   </body>
 </html>

--- a/src/test/e2e_test.ts
+++ b/src/test/e2e_test.ts
@@ -73,9 +73,7 @@ suite('e2e', function() {
                   ]
                       .concat(
                           customResult ?
-                              [
-                                `--global-measurement-expression=window.customResult`
-                              ] :
+                              [`--measurement-expression=window.customResult`] :
                               [])
                       .concat([
                         path.join(testData, 'random-global.html') +

--- a/src/test/e2e_test.ts
+++ b/src/test/e2e_test.ts
@@ -50,42 +50,57 @@ suite('e2e', function() {
 
   for (const browser of browsers) {
     suite(browser, function() {
-      test('window.tachometerResult', hideOutput(async function() {
-             const avgA = 1;
-             const minA = avgA - 0.1;
-             const maxA = avgA + 0.1;
+      for (const customResult of [false, true]) {
+        const name =
+            customResult ? 'window.customResult' : 'window.tachometerResult';
+        const query = customResult ? '&customResult=true' : '';
+        test(
+            name, hideOutput(async function() {
+              const avgA = 1;
+              const minA = avgA - 0.1;
+              const maxA = avgA + 0.1;
 
-             const avgB = 2;
-             const minB = avgB - 0.1;
-             const maxB = avgB + 0.1;
+              const avgB = 2;
+              const minB = avgB - 0.1;
+              const maxB = avgB + 0.1;
 
-             const argv = [
-               `--browser=${browser}`,
-               '--measure=global',
-               '--sample-size=20',
-               '--timeout=0',
-               path.join(testData, 'random-global.html') +
-                   `?min=${minA}&max=${maxA}`,
-               path.join(testData, 'random-global.html') +
-                   `?min=${minB}&max=${maxB}`,
-             ];
+              const argv =
+                  [
+                    `--browser=${browser}`,
+                    '--measure=global',
+                    '--sample-size=20',
+                    '--timeout=0'
+                  ]
+                      .concat(
+                          customResult ?
+                              [
+                                `--global-measurement-expression=window.customResult`
+                              ] :
+                              [])
+                      .concat([
+                        path.join(testData, 'random-global.html') +
+                            `?min=${minA}&max=${maxA}${query}`,
+                        path.join(testData, 'random-global.html') +
+                            `?min=${minB}&max=${maxB}${query}`,
+                      ]);
 
-             const actual = await main(argv);
-             assert.isDefined(actual);
-             assert.lengthOf(actual!, 2);
-             const [a, b] = actual!;
-             const diffAB = a.differences[1]!;
-             const diffBA = b.differences[0]!;
+              const actual = await main(argv);
+              assert.isDefined(actual);
+              assert.lengthOf(actual!, 2);
+              const [a, b] = actual!;
+              const diffAB = a.differences[1]!;
+              const diffBA = b.differences[0]!;
 
-             assert.closeTo(a.stats.mean, avgA, 0.1);
-             assert.closeTo(b.stats.mean, avgB, 0.1);
-             assert.closeTo(ciAverage(diffAB.absolute), avgA - avgB, 0.1);
-             assert.closeTo(ciAverage(diffBA.absolute), avgB - avgA, 0.1);
-             assert.closeTo(
-                 ciAverage(diffAB.relative), (avgA - avgB) / avgB, 0.1);
-             assert.closeTo(
-                 ciAverage(diffBA.relative), (avgB - avgA) / avgA, 0.1);
-           }));
+              assert.closeTo(a.stats.mean, avgA, 0.1);
+              assert.closeTo(b.stats.mean, avgB, 0.1);
+              assert.closeTo(ciAverage(diffAB.absolute), avgA - avgB, 0.1);
+              assert.closeTo(ciAverage(diffBA.absolute), avgB - avgA, 0.1);
+              assert.closeTo(
+                  ciAverage(diffAB.relative), (avgA - avgB) / avgB, 0.1);
+              assert.closeTo(
+                  ciAverage(diffBA.relative), (avgB - avgA) / avgA, 0.1);
+            }));
+      }
 
       test(
           'bench.start/stop', hideOutput(async function() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export const measurements = new Set<Measurement>(['callback', 'fcp', 'global']);
 export interface BenchmarkSpec {
   url: LocalUrl|RemoteUrl;
   measurement: Measurement;
+  globalMeasurementExpression?: string;
   name: string;
   browser: BrowserConfig;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export const measurements = new Set<Measurement>(['callback', 'fcp', 'global']);
 export interface BenchmarkSpec {
   url: LocalUrl|RemoteUrl;
   measurement: Measurement;
-  globalMeasurementExpression?: string;
+  measurementExpression?: string;
   name: string;
   browser: BrowserConfig;
 }


### PR DESCRIPTION
Adds a new `globalMeasurementExpression` configuration option that is used with `"measure": "global"` that allows overriding the default `window.tachometerResult` with an arbitrary expression.

Not entirely sure I threaded through the defaults correctly.

Fixes #130