### PR TITLE
Fix copying the measurementExpression when applying defaults

### DIFF
--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -105,7 +105,7 @@ export async function automaticMode(
         millis = await pollForFirstContentfulPaint(driver);
       } else if (spec.measurement === 'global') {
         millis =
-            await pollForGlobalResult(driver, spec.measurementExpression || '');
+            await pollForGlobalResult(driver, spec.measurementExpression || 'undefined');
       } else {  // bench.start() and bench.stop() callback
         if (server === undefined) {
           throw new Error('Internal error: no server for spec');

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -423,9 +423,12 @@ function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
     measurement = defaults.measurement(url);
   }
   const spec: BenchmarkSpec = {name, url, browser, measurement};
-  if (measurement === 'global' &&
-      partialSpec.measurementExpression === undefined) {
-    spec.measurementExpression = defaults.measurementExpression;
+  if (measurement === 'global') {
+    if (partialSpec.measurementExpression === undefined) {
+      spec.measurementExpression = defaults.measurementExpression;
+    } else {
+      spec.measurementExpression = partialSpec.measurementExpression;
+    }
   }
   return spec;
 }


### PR DESCRIPTION
We also need to add a test for testing the config file, which would have caught this (the `measurement-expression` option is only tested via flags).