### PR TITLE
Add support for CPU throttle.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -16,7 +16,7 @@
                     "description": "Path to the binary to use when launching this browser, instead of the\ndefault one.",
                     "type": "string"
                 },
-                "experimentalCPUThrottlingRate": {
+                "cpuThrottlingRate": {
                     "description": "Optional CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown,\netc). This is currently only supported in headless mode.",
                     "type": "number"
                 },

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,6 +16,10 @@
                     "description": "Path to the binary to use when launching this browser, instead of the\ndefault one.",
                     "type": "string"
                 },
+                "experimentalCPUThrottlingRate": {
+                    "description": "Optional CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown,\netc). This is currently only supported in headless mode.",
+                    "type": "number"
+                },
                 "headless": {
                     "description": "Whether to launch the headless (no GUI) version of this browser.",
                     "type": "boolean"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -63,11 +63,8 @@ export interface BrowserConfig {
   addArguments?: string[];
   /** WebDriver default binary arguments to omit. */
   removeArguments?: string[];
-  /**
-   * Experimental CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown,
-   * etc).
-   */
-  experimentalCPUThrottlingRate?: number;
+  /** CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown, etc). */
+  cpuThrottlingRate?: number;
 }
 
 export interface WindowSize {
@@ -238,11 +235,10 @@ export async function openAndSwitchToNewTab(
   const driverWithSendDevToolsCommand =
       (driver as {} as WithSendDevToolsCommand);
   if (driverWithSendDevToolsCommand.sendDevToolsCommand &&
-      config.experimentalCPUThrottlingRate !== undefined) {
+      config.cpuThrottlingRate !== undefined) {
     // Enables CPU throttling to emulate slow CPUs.
     await driverWithSendDevToolsCommand.sendDevToolsCommand(
-        'Emulation.setCPUThrottlingRate',
-        {rate: config.experimentalCPUThrottlingRate});
+        'Emulation.setCPUThrottlingRate', {rate: config.cpuThrottlingRate});
   }
 }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -63,6 +63,11 @@ export interface BrowserConfig {
   addArguments?: string[];
   /** WebDriver default binary arguments to omit. */
   removeArguments?: string[];
+  /**
+   * Experimental CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown,
+   * etc).
+   */
+  experimentalCPUThrottlingRate?: number;
 }
 
 export interface WindowSize {
@@ -225,6 +230,19 @@ export async function openAndSwitchToNewTab(
     // For IE we get a new window instead of a new tab, so we need to resize
     // every time.
     await driver.manage().window().setRect(config.windowSize);
+  }
+  type WithSendDevToolsCommand = {
+    sendDevToolsCommand?: (command: string, config: {}) => Promise<void>,
+  };
+
+  const driverWithSendDevToolsCommand =
+      (driver as {} as WithSendDevToolsCommand);
+  if (driverWithSendDevToolsCommand.sendDevToolsCommand &&
+      config.experimentalCPUThrottlingRate !== undefined) {
+    // Enables CPU throttling to emulate slow CPUs.
+    await driverWithSendDevToolsCommand.sendDevToolsCommand(
+        'Emulation.setCPUThrottlingRate',
+        {rate: config.experimentalCPUThrottlingRate});
   }
 }
 

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -202,6 +202,12 @@ interface ChromeConfig extends BrowserConfigBase {
    * launching the browser, which you would like to omit.
    */
   removeArguments?: string[];
+
+  /**
+   * Optional CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown,
+   * etc). This is currently only supported in headless mode.
+   */
+  experimentalCPUThrottlingRate?: number;
 }
 
 interface FirefoxConfig extends BrowserConfigBase {
@@ -360,6 +366,10 @@ function parseBrowserObject(config: BrowserConfigs): BrowserConfig {
       height: defaultWindowHeight,
     },
   };
+
+  if ('experimentalCPUThrottlingRate' in config) {
+    parsed.experimentalCPUThrottlingRate = config.experimentalCPUThrottlingRate;
+  }
   if (config.remoteUrl) {
     parsed.remoteUrl = config.remoteUrl;
   }

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -207,7 +207,7 @@ interface ChromeConfig extends BrowserConfigBase {
    * Optional CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown,
    * etc). This is currently only supported in headless mode.
    */
-  experimentalCPUThrottlingRate?: number;
+  cpuThrottlingRate?: number;
 }
 
 interface FirefoxConfig extends BrowserConfigBase {
@@ -367,8 +367,8 @@ function parseBrowserObject(config: BrowserConfigs): BrowserConfig {
     },
   };
 
-  if ('experimentalCPUThrottlingRate' in config) {
-    parsed.experimentalCPUThrottlingRate = config.experimentalCPUThrottlingRate;
+  if ('cpuThrottlingRate' in config) {
+    parsed.cpuThrottlingRate = config.cpuThrottlingRate;
   }
   if (config.remoteUrl) {
     parsed.remoteUrl = config.remoteUrl;

--- a/src/test/configfile_test.ts
+++ b/src/test/configfile_test.ts
@@ -77,7 +77,7 @@ suite('config', () => {
             browser: {
               ...defaultBrowser,
               name: 'chrome',
-              experimentalCPUThrottlingRate: 6,
+              cpuThrottlingRate: 6,
             },
             measurement: 'fcp',
             url: 'http://example.com?foo=bar',
@@ -128,7 +128,7 @@ suite('config', () => {
             browser: {
               ...defaultBrowser,
               name: 'chrome',
-              experimentalCPUThrottlingRate: 6,
+              cpuThrottlingRate: 6,
             },
             measurement: 'fcp',
             url: {

--- a/src/test/configfile_test.ts
+++ b/src/test/configfile_test.ts
@@ -72,6 +72,16 @@ suite('config', () => {
               },
             },
           },
+          {
+            name: 'local-or-remote',
+            browser: {
+              ...defaultBrowser,
+              name: 'chrome',
+              experimentalCPUThrottlingRate: 6,
+            },
+            measurement: 'fcp',
+            url: 'http://example.com?foo=bar',
+          },
         ],
       };
       const expected: Partial<Config> = {
@@ -111,6 +121,19 @@ suite('config', () => {
                   'bar': '=1.2.3',
                 },
               },
+            },
+          },
+          {
+            name: 'local-or-remote',
+            browser: {
+              ...defaultBrowser,
+              name: 'chrome',
+              experimentalCPUThrottlingRate: 6,
+            },
+            measurement: 'fcp',
+            url: {
+              kind: 'remote',
+              url: 'http://example.com?foo=bar',
             },
           },
         ],


### PR DESCRIPTION
It uses an experimental Webdriver method (sendDevToolsCommand) to set the rate of CPU throttling. As of today it works in chrome headless mode.
https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/CHANGES.md

Fixes https://github.com/Polymer/tachometer/issues/57