### PR TITLE
Open new tabs with noopener=yes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+-   Improved reliability of measurements by opening new tabs with
+    `noopener=yes`. This change appears to reduce or eliminate shared code
+    caching across benchmarks, removing effects such as the order of
+    benchmarks reliably producing different results.
 
 ## [0.4.14] 2019-11-05
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -216,7 +216,13 @@ export async function openAndSwitchToNewTab(
   if (tabsBefore.length !== 1) {
     throw new Error(`Expected only 1 open tab, got ${tabsBefore.length}`);
   }
-  await driver.executeScript('window.open();');
+  // "noopener=yes" prevents the new window from being able to access the
+  // first window. We set that here because in Chrome (and perhaps other
+  // browsers) we see a very significant improvement in the reliability of
+  // measurements, in particular it appears to eliminate interference between
+  // code across runs. It is likely this flag increases process isolation in a
+  // way that prevents code caching across tabs.
+  await driver.executeScript('window.open("", "", "noopener=yes");');
   const tabsAfter = await driver.getAllWindowHandles();
   const newTabs = tabsAfter.filter((tab) => tab !== tabsBefore[0]);
   if (newTabs.length !== 1) {


### PR DESCRIPTION
This appears to eliminate recent measurement problems that we have observed, where changing the order of benchmarks can significantly and reliably affect the results. It is likely noopener gives us
additional process isolation and prevents code cache sharing.