### PR TITLE
Add "preferences" browser JSON config for Firefox about:config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### Changed
+### Added
+
+-   Added `preferences` property to Firefox browser config, which can be used
+    to set any option that is usually set from the about:config page.
+
+### Fixed
 
 -   Files are no longer cached by the server when using `--manual` mode.
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ To pass additional arguments to the binary (Chrome and Firefox only), use the
 arguments that WebDriver sets by default (Chrome only), use `removeArguments`
 (see example in next section).
 
+To configure Firefox preferences that are usually set from the `about:config`
+page, use the `preferences` property in the browser JSON config.
+
 ### Profiles
 
 It is normally reccommended to use the default behavior whereby a new, empty

--- a/config.schema.json
+++ b/config.schema.json
@@ -182,6 +182,17 @@
                     ],
                     "type": "string"
                 },
+                "preferences": {
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number",
+                            "boolean"
+                        ]
+                    },
+                    "description": "Advanced preferences that are usually set from the about:config page\nin Firefox (see\nhttps://support.mozilla.org/en-US/kb/about-config-editor-firefox).",
+                    "type": "object"
+                },
                 "remoteUrl": {
                     "description": "A remote WebDriver server HTTP address to launch the browser from.",
                     "type": "string"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -65,6 +65,8 @@ export interface BrowserConfig {
   removeArguments?: string[];
   /** CPU Throttling rate. (1 is no throttle, 2 is 2x slowdown, etc). */
   cpuThrottlingRate?: number;
+  /** Advanced preferences usually set from the about:config page. */
+  preferences?: {[name: string]: string|number|boolean};
 }
 
 export interface WindowSize {
@@ -187,6 +189,11 @@ function chromeOpts(config: BrowserConfig): chrome.Options {
 
 function firefoxOpts(config: BrowserConfig): firefox.Options {
   const opts = new firefox.Options();
+  if (config.preferences) {
+    for (const [name, value] of Object.entries(config.preferences)) {
+      opts.setPreference(name, value);
+    }
+  }
   if (config.binary) {
     opts.setBinary(config.binary);
   }

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -229,6 +229,13 @@ interface FirefoxConfig extends BrowserConfigBase {
    * Additional command-line arguments to pass when launching the browser.
    */
   addArguments?: string[];
+
+  /**
+   * Advanced preferences that are usually set from the about:config page
+   * in Firefox (see
+   * https://support.mozilla.org/en-US/kb/about-config-editor-firefox).
+   */
+  preferences?: {[name: string]: string|number|boolean};
 }
 
 interface SafariConfig extends BrowserConfigBase {
@@ -382,6 +389,9 @@ function parseBrowserObject(config: BrowserConfigs): BrowserConfig {
   }
   if ('removeArguments' in config && config.removeArguments) {
     parsed.removeArguments = config.removeArguments;
+  }
+  if ('preferences' in config && config.preferences) {
+    parsed.preferences = config.preferences;
   }
   return parsed;
 }

--- a/src/test/configfile_test.ts
+++ b/src/test/configfile_test.ts
@@ -61,6 +61,9 @@ suite('config', () => {
             browser: {
               ...defaultBrowser,
               name: 'firefox',
+              preferences: {
+                'layout.css.shadow-parts.enabled': true,
+              },
             },
             measurement: 'callback',
             url: 'mybench/index.html?foo=bar',
@@ -108,6 +111,9 @@ suite('config', () => {
             browser: {
               ...defaultBrowser,
               name: 'firefox',
+              preferences: {
+                'layout.css.shadow-parts.enabled': true,
+              },
             },
             measurement: 'callback',
             url: {


### PR DESCRIPTION
Fixes https://github.com/Polymer/tachometer/issues/140

Note Chrome doesn't have a way to configure this that I could find, there seem to just be lots of CLI flags instead (which are already supported).