### PR TITLE
Enable building on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,6 +1063,16 @@
         "p-map": "^2.0.0",
         "pify": "^4.0.1",
         "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "delayed-stream": {
@@ -2917,9 +2927,10 @@
       }
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -2948,6 +2959,16 @@
         "rimraf": "^2.6.3",
         "tmp": "0.0.30",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "rm -rf lib/ client/lib/ && mkdir lib && npm run generate-json-schema && tsc && tsc -p client/ && npm run lint",
+    "build": "rimraf lib/ client/lib/ && mkdir lib && npm run generate-json-schema && tsc && tsc -p client/ && npm run lint",
     "generate-json-schema": "typescript-json-schema tsconfig.json ConfigFile --include src/configfile.ts --required --noExtraProps > config.schema.json",
     "lint": "tslint --project . --format stylish",
-    "format": "find src/ client/src/ -name \"*.ts\" | xargs clang-format --style=file -i",
+    "format": "clang-format --style=file -i \"--glob=./{client,}/src/*.ts\"",
     "test": "npm run build && mocha"
   },
   "repository": {
@@ -88,6 +88,7 @@
     "clang-format": "^1.3.0",
     "mocha": "^6.2.2",
     "node-fetch": "^2.6.0",
+    "rimraf": "^3.0.2",
     "tslint": "^5.12.1",
     "typescript": "^3.6.4",
     "typescript-json-schema": "^0.41.0"


### PR DESCRIPTION
Enable building on Windows machines by slightly modifying scripts in package.json to use cross-platform commands and options