### PR TITLE
Support running npm on Windows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,8 +11,6 @@
 
 require('source-map-support').install();
 
-import {execFile} from 'child_process';
-import {promisify} from 'util';
 import * as path from 'path';
 import ansi = require('ansi-escape-sequences');
 import * as semver from 'semver';
@@ -27,6 +25,7 @@ import {ResultStatsWithDifferences} from './stats';
 import {prepareVersionDirectory, makeServerPlans} from './versions';
 import {manualMode} from './manual';
 import {automaticMode} from './automatic';
+import {runNpm} from './util';
 
 const installedVersion = (): string =>
     require(path.join('..', 'package.json')).version;
@@ -56,9 +55,8 @@ export async function main(argv: string[]):
 }
 
 async function latestVersionFromNpm(): Promise<string> {
-  const {stdout} = await promisify(execFile)(
-      'npm', ['info', 'tachometer@latest', 'version']);
-  return stdout.trim();
+  const stdout = await runNpm(['info', 'tachometer@latest', 'version']);
+  return stdout.toString('utf8').trim();
 }
 
 function notifyIfOutdated(latestVersion: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,8 +9,10 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import {execFile, ExecFileOptions} from 'child_process';
 import * as fsExtra from 'fs-extra';
 import {URL} from 'url';
+import {promisify} from 'util';
 
 /** Return whether the given string is a valid HTTP URL. */
 export function isHttpUrl(str: string): boolean {
@@ -39,4 +41,10 @@ export async function fileKind(path: string): Promise<'file'|'dir'|undefined> {
     }
     throw e;
   }
+}
+
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+export async function runNpm(
+    args: string[], options?: ExecFileOptions): Promise<string|Buffer> {
+  return promisify(execFile)(npmCmd, args, options).then(({stdout}) => stdout);
 }

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -9,14 +9,13 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import * as child_process from 'child_process';
 import * as crypto from 'crypto';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 
 import {MountPoint} from './server';
 import {BenchmarkSpec, NpmPackageJson, PackageDependencyMap, PackageVersion} from './types';
-import {fileKind} from './util';
+import {fileKind, runNpm} from './util';
 
 /**
  * Parse an array of strings of the form <package>@<version>.
@@ -176,21 +175,6 @@ export function hashStrings(...strings: string[]) {
       .digest('hex');
 }
 
-/**
- * Run "npm install" in the given directory.
- */
-async function npmInstall(cwd: string): Promise<void> {
-  return new Promise(
-      (resolve, reject) =>
-          child_process.execFile('npm', ['install'], {cwd}, (error) => {
-            if (error) {
-              reject(error);
-            } else {
-              resolve();
-            }
-          }));
-}
-
 const tachometerVersion =
     require(path.join(__dirname, '..', 'package.json')).version;
 
@@ -238,5 +222,5 @@ export async function prepareVersionDirectory(
   console.log(`\nRunning npm install:\n  ${installDir}\n`);
   await fsExtra.ensureDir(installDir);
   await fsExtra.writeFile(packageJsonPath, serializedPackageJson);
-  await npmInstall(installDir);
+  await runNpm(['install'], {cwd: installDir});
 }


### PR DESCRIPTION
`execFile('npm')` doesn't work on Windows 😢 But `execFile('npm.cmd')` does work 😄 So this PR introduces a little helper `runNpm` to encapsulate the logic to exec npm cross-platform.

Currently running tachometer on Windows results in UnhandledPromiseRejections being logged to console cuz the npm version check fails. Also the --package-version feature fails on Windows currently.

This PR fixes both of those issues.