### PR TITLE
Add Windows fixes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 -   Files are no longer cached by the server when using `--manual` mode.
+-   Running `npm` commands is fixed on Windows
+-   Improved Windows support in build scripts
 
 ## [0.4.16] 2019-12-20
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -167,7 +167,6 @@ export function applyDefaults(partial: Partial<Config>): Config {
 export async function urlFromLocalPath(
     rootDir: string, diskPath: string): Promise<string> {
   const serverRelativePath = path.relative(rootDir, diskPath);
-  // TODO Test on Windows.
   if (serverRelativePath.startsWith('..')) {
     throw new Error(
         'File or directory is not accessible from server root: ' + diskPath);
@@ -178,7 +177,6 @@ export async function urlFromLocalPath(
     throw new Error(`No such file or directory: ${diskPath}`);
   }
 
-  // TODO Test on Windows.
   let urlPath = `/${serverRelativePath.replace(path.win32.sep, '/')}`;
   if (kind === 'dir') {
     if (await fileKind(path.join(diskPath, 'index.html')) !== 'file') {


### PR DESCRIPTION
Windows support looks good to me! I tested the `-p` and `--root` options on Windows and they seem to work as expected so I removed the TODOs related to `--root`.