### PR TITLE
Document `--manual` flag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,3 +600,4 @@ Flag                    -  | Default     | Description
 `--force-clean-npm-install`| `false`     | Always do a from-scratch NPM install when using custom package versions. ([details](#swap-npm-dependencies))
 `--csv-file`               | *none*      | Save results to this CSV file.
 `--json-file`              | *none*      | Save results to this JSON file.
+`--manual`                 | `false`     | Don't run automatically, just show URLs and collect results


### PR DESCRIPTION
Was looking at implementing something similar to `--manual` when I suddenly discovered it was already there! So just thought I'd add it to the README 😄 