### PR TITLE
Root koa-node-resolve middleware at npmInstall root if available

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,6 +134,7 @@ $ tach http://example.com
         host: opts.host,
         ports: opts.port,
         root: config.root,
+        npmInstalls,
         mountPoints,
         resolveBareModules: config.resolveBareModules,
         cache: config.mode !== 'manual',

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,11 +23,13 @@ import bodyParser = require('koa-bodyparser');
 import {nodeResolve} from 'koa-node-resolve';
 
 import {BenchmarkResponse, Deferred} from './types';
+import {NpmInstall} from './versions';
 
 export interface ServerOpts {
   host: string;
   ports: number[];
   root: string;
+  npmInstalls: NpmInstall[];
   mountPoints: MountPoint[];
   resolveBareModules: boolean;
   cache: boolean;
@@ -97,8 +99,12 @@ export class Server {
     app.use(this.serveBenchLib.bind(this));
 
     if (opts.resolveBareModules === true) {
+      const npmRoot = opts.npmInstalls.length > 0 ?
+          opts.npmInstalls[0].installDir :
+          opts.root;
+
       app.use(nodeResolve({
-        root: opts.root,
+        root: npmRoot,
         // TODO Use default logging options after issues resolved:
         // https://github.com/Polymer/koa-node-resolve/issues/16
         // https://github.com/Polymer/koa-node-resolve/issues/17

--- a/src/test/data/alt_npm_install_dir/node_modules/dep1/dep1-main.js
+++ b/src/test/data/alt_npm_install_dir/node_modules/dep1/dep1-main.js
@@ -1,0 +1,1 @@
+export const dep1 = 1111;

--- a/src/test/data/alt_npm_install_dir/node_modules/dep1/package.json
+++ b/src/test/data/alt_npm_install_dir/node_modules/dep1/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "dep1-main.js"
+}

--- a/src/test/data/alt_npm_install_dir/package.json
+++ b/src/test/data/alt_npm_install_dir/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "dep1": "0.0.0"
+  }
+}

--- a/src/test/server_test.ts
+++ b/src/test/server_test.ts
@@ -24,6 +24,7 @@ suite('server', () => {
       ports: [0],  // random
       root: testData,
       resolveBareModules: true,
+      npmInstalls: [],
       mountPoints: [{
         diskPath: testData,
         urlPath: '/',


### PR DESCRIPTION
If the server plan includes an `npmInstall` override, use that as the `koa-node-resolve` root config instead of the server root. This change allows multiple servers running with custom package versions to resolve files local to their npm overrides.

Includes some tests that fail if the code is removed.

Fixes #137 

Requires Polymer/koa-node-resolve#28 to work on Windows