### PR TITLE
Bump koa-node-resolve to 1.0.0-pre.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",
     "koa-mount": "^4.0.0",
-    "koa-node-resolve": "^1.0.0-pre.6",
+    "koa-node-resolve": "^1.0.0-pre.7",
     "koa-router": "^7.4.0",
     "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",


### PR DESCRIPTION
Brings in Windows fixes for koa-node-resolve