### PR TITLE
Add CSV/JSON output for raw samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Added `--csv-file-raw` flag, which outputs a CSV file containing all raw
+  measurement results for each benchmark. Columns correspond to benchmarks, rows
+  correspond to sample measurements in milliseconds. The first row is a header
+  row containing the name of each benchmark.
+
+- Added `samples` property to the JSON file emitted by `--json-file` which
+  contains all raw sample measurements in milliseconds.
 
 ## [0.4.19] 2020-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [0.4.20] 2020-07-09
 
 - Added `--csv-file-raw` flag, which outputs a CSV file containing all raw
   measurement results for each benchmark. Columns correspond to benchmarks, rows

--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Flag                    -  | Default     | Description
 `--remote-accessible-host` | matches `--host` | When using a browser over a remote WebDriver connection, the URL that those browsers should use to access the local tachometer server ([details](#remote-control))
 `--npm-install-dir`        | system temp dir | Where to install custom package versions. ([details](#swap-npm-dependencies))
 `--force-clean-npm-install`| `false`     | Always do a from-scratch NPM install when using custom package versions. ([details](#swap-npm-dependencies))
-`--csv-file`               | *none*      | Save results to this CSV file.
+`--csv-file`               | *none*      | Save statistical summary to this CSV file.
+`--csv-file-raw`           | *none*      | Save raw sample measurements to this CSV file.
 `--json-file`              | *none*      | Save results to this JSON file.
 `--manual`                 | `false`     | Don't run automatically, just show URLs and collect results

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Web benchmark runner",
   "main": "index.js",
   "directories": {

--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -18,7 +18,7 @@ import ansi = require('ansi-escape-sequences');
 import {jsonOutput, legacyJsonOutput} from './json-output';
 import {browserSignature, makeDriver, openAndSwitchToNewTab, pollForGlobalResult, pollForFirstContentfulPaint} from './browser';
 import {BenchmarkResult, BenchmarkSpec} from './types';
-import {formatCsv} from './csv';
+import {formatCsvStats, formatCsvRaw} from './csv';
 import {ResultStats, ResultStatsWithDifferences, horizonsResolved, summaryStats, computeDifferences} from './stats';
 import {verticalTermResultTable, horizontalTermResultTable, verticalHtmlResultTable, horizontalHtmlResultTable, automaticResultTable, spinner, benchmarkOneLiner} from './format';
 import {Config} from './config';
@@ -272,8 +272,12 @@ export async function automaticMode(
     await fsExtra.writeJSON(config.legacyJsonFile, json);
   }
 
-  if (config.csvFile) {
-    await fsExtra.writeFile(config.csvFile, formatCsv(withDifferences));
+  if (config.csvFileStats) {
+    await fsExtra.writeFile(
+        config.csvFileStats, formatCsvStats(withDifferences));
+  }
+  if (config.csvFileRaw) {
+    await fsExtra.writeFile(config.csvFileRaw, formatCsvRaw(withDifferences));
   }
 
   if (completeGithubCheck !== undefined) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,17 +39,19 @@ export interface Config {
   resolveBareModules: boolean;
   remoteAccessibleHost: string;
   forceCleanNpmInstall: boolean;
-  csvFile: string;
+  csvFileStats: string;
+  csvFileRaw: string;
 }
 
 export async function makeConfig(opts: Opts): Promise<Config> {
   // These options are only controlled by flags.
-  const baseConfig = {
+  const baseConfig: Partial<Config> = {
     mode: (opts.manual === true ? 'manual' : 'automatic') as
         ('manual' | 'automatic'),
     jsonFile: opts['json-file'],
     legacyJsonFile: opts['save'],
-    csvFile: opts['csv-file'],
+    csvFileStats: opts['csv-file'],
+    csvFileRaw: opts['csv-file-raw'],
     forceCleanNpmInstall: opts['force-clean-npm-install'],
     githubCheck: opts['github-check'] ?
         parseGithubCheckFlag(opts['github-check']) :
@@ -134,7 +136,9 @@ export async function makeConfig(opts: Opts): Promise<Config> {
 export function applyDefaults(partial: Partial<Config>): Config {
   return {
     benchmarks: partial.benchmarks !== undefined ? partial.benchmarks : [],
-    csvFile: partial.csvFile !== undefined ? partial.csvFile : '',
+    csvFileStats: partial.csvFileStats !== undefined ? partial.csvFileStats :
+                                                       '',
+    csvFileRaw: partial.csvFileRaw !== undefined ? partial.csvFileRaw : '',
     forceCleanNpmInstall: partial.forceCleanNpmInstall !== undefined ?
         partial.forceCleanNpmInstall :
         defaults.forceCleanNpmInstall,

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -16,9 +16,9 @@ import {ResultStatsWithDifferences} from './stats';
 const precision = 5;
 
 /**
- * Format results as a CSV file string.
+ * Format statistical results as a CSV file string.
  */
-export function formatCsv(results: ResultStatsWithDifferences[]): string {
+export function formatCsvStats(results: ResultStatsWithDifferences[]): string {
   // Note the examples in ./test/csv_test.ts should make this easier to
   // understand.
   const h1 = ['', '', ''];
@@ -50,4 +50,33 @@ export function formatCsv(results: ResultStatsWithDifferences[]): string {
     rows.push(row);
   }
   return csvStringify([h1, h2, h3, ...rows]);
+}
+
+/**
+ * Format raw sample results as a CSV file string.
+ *
+ * Columns correspond to benchmarks. Rows correspond to sample iterations. The
+ * first row is headers containing the benchmark names.
+ *
+ * For example:
+ *
+ * foo, bar, baz
+ * 1.2, 5.5, 9.4
+ * 1.8, 5.6, 9.1
+ * 1.3, 5.2, 9.8
+ */
+export function formatCsvRaw(results: ResultStatsWithDifferences[]): string {
+  const headers = [];
+  const rows: Array<number[]> = [];
+  for (let r = 0; r < results.length; r++) {
+    const {result} = results[r];
+    headers.push(result.name);
+    for (let m = 0; m < result.millis.length; m++) {
+      if (rows[m] === undefined) {
+        rows[m] = [];
+      }
+      rows[m][r] = result.millis[m];
+    }
+  }
+  return csvStringify([headers, ...rows]);
 }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -134,6 +134,12 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
     defaultValue: '',
   },
   {
+    name: 'csv-file-raw',
+    description: 'Save raw benchmark measurement samples to this CSV file.',
+    type: String,
+    defaultValue: '',
+  },
+  {
     name: 'measure',
     description: 'Which time interval to measure. Options:\n' +
         '* callback: call bench.start() and bench.stop() (default)\n' +
@@ -220,6 +226,7 @@ export interface Opts {
   'window-size': string;
   'force-clean-npm-install': boolean;
   'csv-file': string;
+  'csv-file-raw': string;
   'json-file': string;
 
   // Extra arguments not associated with a flag are put here. These are our

--- a/src/json-output.ts
+++ b/src/json-output.ts
@@ -22,6 +22,7 @@ interface Benchmark {
   name: string;
   mean: ConfidenceInterval;
   differences: Array<Difference|null>;
+  samples: number[];
 }
 
 interface Difference {
@@ -57,6 +58,7 @@ export function jsonOutput(results: ResultStatsWithDifferences[]):
     }
     benchmarks.push({
       name: result.result.name,
+      samples: result.result.millis,
       mean: {
         low: result.stats.meanCI.low,
         high: result.stats.meanCI.high,

--- a/src/manual.ts
+++ b/src/manual.ts
@@ -22,7 +22,8 @@ import {BenchmarkSpec} from './types';
  */
 export async function manualMode(
     config: Config, servers: Map<BenchmarkSpec, Server>) {
-  if (config.csvFile || config.jsonFile || config.legacyJsonFile) {
+  if (config.csvFileStats || config.csvFileRaw || config.jsonFile ||
+      config.legacyJsonFile) {
     throw new Error(`Can't save results in manual mode`);
   }
 

--- a/src/test/config_test.ts
+++ b/src/test/config_test.ts
@@ -47,7 +47,8 @@ suite('makeConfig', function() {
       remoteAccessibleHost: '',
       jsonFile: '',
       legacyJsonFile: '',
-      csvFile: '',
+      csvFileStats: '',
+      csvFileRaw: '',
       githubCheck: undefined,
       benchmarks: [
         {
@@ -86,7 +87,8 @@ suite('makeConfig', function() {
       remoteAccessibleHost: '',
       jsonFile: '',
       legacyJsonFile: '',
-      csvFile: '',
+      csvFileStats: '',
+      csvFileRaw: '',
       // TODO(aomarks) Be consistent about undefined vs unset.
       githubCheck: undefined,
       benchmarks: [
@@ -127,7 +129,8 @@ suite('makeConfig', function() {
       remoteAccessibleHost: '',
       jsonFile: '',
       legacyJsonFile: '',
-      csvFile: '',
+      csvFileStats: '',
+      csvFileRaw: '',
       githubCheck: undefined,
       benchmarks: [
         {
@@ -156,13 +159,15 @@ suite('makeConfig', function() {
   test('config file with output files and force clean install', async () => {
     const argv = [
       '--config=random-global.json',
-      '--csv-file=out.csv',
+      '--csv-file=stats.csv',
+      '--csv-file-raw=raw.csv',
       '--json-file=out.json',
       '--force-clean-npm-install',
     ];
     const expected: Config = {
       mode: 'automatic',
-      csvFile: 'out.csv',
+      csvFileStats: 'stats.csv',
+      csvFileRaw: 'raw.csv',
       jsonFile: 'out.json',
       legacyJsonFile: '',
       forceCleanNpmInstall: true,

--- a/src/test/csv_test.ts
+++ b/src/test/csv_test.ts
@@ -13,7 +13,7 @@ import {assert} from 'chai';
 import {suite, test} from 'mocha';
 
 import {ConfigFile} from '../configfile';
-import {formatCsv} from '../csv';
+import {formatCsvRaw, formatCsvStats} from '../csv';
 import {fakeResults} from './test_helpers';
 
 /**
@@ -24,7 +24,7 @@ const removePadding = (readable: string): string =>
     readable.replace(/ *, */g, ',').replace(/ *\n */gm, '\n').trim() + '\n';
 
 suite('csv', () => {
-  test('2x2 matrix with quoting', async () => {
+  test('stats: 2x2 matrix with quoting', async () => {
     const config: ConfigFile = {
       benchmarks: [
         {
@@ -38,13 +38,43 @@ suite('csv', () => {
       ],
     };
     const results = await fakeResults(config);
-    const actual = formatCsv(results);
+    const actual = formatCsvStats(results);
     const expected = removePadding(`
          ,         ,         ,    vs foo,           ,          ,         ,  "vs bar,baz",           ,          ,
          ,       ms,         ,  % change,           , ms change,         ,      % change,           , ms change,
          ,      min,      max,       min,        max,       min,      max,           min,        max,       min,      max
       foo,  8.56459, 11.43541,          ,           ,          ,         ,    -58.02419%, -41.97581%, -12.02998, -7.97002
 "bar,baz", 18.56459, 21.43541, 67.90324%, 132.09676%,   7.97002, 12.02998,              ,           ,          ,
+    `);
+    assert.equal(actual, expected);
+  });
+
+  test('raw samples: 2x2 matrix with quoting', async () => {
+    const config: ConfigFile = {
+      sampleSize: 4,
+      benchmarks: [
+        {
+          name: 'foo',
+          url: 'http://example.com?foo',
+        },
+        {
+          name: 'bar,baz',
+          url: 'http://example.com?bar,baz',
+        },
+        {
+          name: 'qux',
+          url: 'http://example.com?qux',
+        },
+      ],
+    };
+    const results = await fakeResults(config);
+    const actual = formatCsvRaw(results);
+    const expected = removePadding(`
+    foo, "bar,baz", qux
+    5,   15,        25
+    5,   15,        25
+    15,  25,        35
+    15,  25,        35
     `);
     assert.equal(actual, expected);
   });

--- a/src/test/json-output_test.ts
+++ b/src/test/json-output_test.ts
@@ -62,6 +62,10 @@ suite('jsonOutput', () => {
       benchmarks: [
         {
           name: 'foo',
+          samples: [
+            ...new Array(25).fill(5),
+            ...new Array(25).fill(15),
+          ],
           mean: {
             low: 8.56459,
             high: 11.43541,
@@ -82,6 +86,10 @@ suite('jsonOutput', () => {
         },
         {
           name: 'bar',
+          samples: [
+            ...new Array(25).fill(15),
+            ...new Array(25).fill(25),
+          ],
           mean: {
             low: 18.56459,
             high: 21.43541,


### PR DESCRIPTION
- Added `--csv-file-raw` flag, which outputs a CSV file containing all raw sample measurements in milliseconds. Columns are benchmarks, rows are samples. First row is a header column with benchmark names. For example:

  ```
  foo, bar, baz
  1.2, 5.5, 9.4
  1.8, 5.6, 9.1
  1.3, 5.2, 9.8
  ```

- Added `samples` output to the existing JSON file output, containing the same raw sample measurements in milliseconds.

- Prepare to release `v0.4.20`.

Fixes https://github.com/Polymer/tachometer/issues/162