### PR TITLE
Fix "main" entry in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix `main` entry in package.json to point to `lib/cli.js`.
 
 ## [0.4.20] 2020-07-09
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tachometer",
   "version": "0.4.20",
   "description": "Web benchmark runner",
-  "main": "index.js",
+  "main": "lib/cli.js",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
It seems some consumers run the `main` function directly (e.g. [spectrum-web-components](https://github.com/adobe/spectrum-web-components/blob/eafa852b5eb0b921129b532eb322cc71a9c9d996/test/benchmark/cli.ts#L1), [material-components-web-components](https://github.com/material-components/material-components-web-components/blob/ec11ae6e07d0e4912c2f65335e1fffa6e33f4d04/test/src/benchmark/cli.ts#L21)). Thought it may be easier for people to do this if we just fix up our "main" entry in package.json to point to `lib/cli.js` enabling `const { main } = require('tachometer');`.

Personally, I'd like this so I can do something like `require.resolve('tachometer')` to determine where tachometer is installed so I can manually run `node node_modules/tachometer/bin/tach.js` (though maybe I should just use `main`...).