### PR TITLE
Extend JSON output to match table printed to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Added more fields to JSON output file to more closely match table printed to the console
 
 ## [0.4.20] 2020-07-09
 

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -175,9 +175,6 @@ interface WindowSize {
   height: number;
 }
 
-export const defaultWindowWidth = 1024;
-export const defaultWindowHeight = 768;
-
 interface ChromeConfig extends BrowserConfigBase {
   name: 'chrome';
 
@@ -310,8 +307,8 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
       browser = {
         ...parseBrowserConfigString(benchmark.browser),
         windowSize: {
-          width: defaultWindowWidth,
-          height: defaultWindowHeight,
+          width: defaults.windowWidth,
+          height: defaults.windowHeight,
         },
       };
     } else {
@@ -368,10 +365,10 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
 function parseBrowserObject(config: BrowserConfigs): BrowserConfig {
   const parsed: BrowserConfig = {
     name: config.name,
-    headless: ('headless' in config && config.headless) || false,
+    headless: ('headless' in config && config.headless) || defaults.headless,
     windowSize: ('windowSize' in config && config.windowSize) || {
-      width: defaultWindowWidth,
-      height: defaultWindowHeight,
+      width: defaults.windowWidth,
+      height: defaults.windowHeight,
     },
   };
 
@@ -433,10 +430,10 @@ function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   if (browser === undefined) {
     browser = {
       name: defaults.browserName,
-      headless: false,
+      headless: defaults.headless,
       windowSize: {
-        width: defaultWindowWidth,
-        height: defaultWindowHeight,
+        width: defaults.windowWidth,
+        height: defaults.windowHeight,
       },
     };
   }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -16,6 +16,7 @@ export const windowWidth = 1024;
 export const windowHeight = 768;
 export const root = '.';
 export const browserName: BrowserName = 'chrome';
+export const headless = false;
 export const sampleSize = 50;
 export const timeout = 3;
 export const horizons = ['0%'] as const;

--- a/src/json-output.ts
+++ b/src/json-output.ts
@@ -11,6 +11,7 @@
 
 import * as systeminformation from 'systeminformation';
 
+import {BrowserConfig} from './browser';
 import {ResultStatsWithDifferences} from './stats';
 import {BenchmarkResult} from './types';
 
@@ -18,8 +19,15 @@ export interface JsonOutputFile {
   benchmarks: Benchmark[];
 }
 
+interface BrowserConfigResult extends BrowserConfig {
+  userAgent?: string;
+}
+
 interface Benchmark {
   name: string;
+  bytesSent: number;
+  version?: string;
+  browser?: BrowserConfigResult;
   mean: ConfidenceInterval;
   differences: Array<Difference|null>;
   samples: number[];
@@ -58,12 +66,18 @@ export function jsonOutput(results: ResultStatsWithDifferences[]):
     }
     benchmarks.push({
       name: result.result.name,
-      samples: result.result.millis,
+      bytesSent: result.result.bytesSent,
+      version: result.result.version ? result.result.version : undefined,
+      browser: {
+        ...result.result.browser,
+        userAgent: result.result.userAgent,
+      },
       mean: {
         low: result.stats.meanCI.low,
         high: result.stats.meanCI.high,
       },
       differences,
+      samples: result.result.millis,
     });
   }
   return {benchmarks};

--- a/src/test/json-output_test.ts
+++ b/src/test/json-output_test.ts
@@ -62,6 +62,15 @@ suite('jsonOutput', () => {
       benchmarks: [
         {
           name: 'foo',
+          bytesSent: 1024,
+          version: undefined,
+          browser: {
+            name: 'chrome',
+            headless: false,
+            windowSize: {width: 1024, height: 768},
+            userAgent:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36',
+          },
           samples: [
             ...new Array(25).fill(5),
             ...new Array(25).fill(15),
@@ -86,6 +95,15 @@ suite('jsonOutput', () => {
         },
         {
           name: 'bar',
+          bytesSent: 2048,
+          version: undefined,
+          browser: {
+            name: 'chrome',
+            headless: false,
+            windowSize: {width: 1024, height: 768},
+            userAgent:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36',
+          },
           samples: [
             ...new Array(25).fill(15),
             ...new Array(25).fill(25),


### PR DESCRIPTION
I'd like to be able to reproduce something similar to the automatic results table printed to the console from the `--json-file` output file, so this PR adds more fields to the JSON output file to enable that scenario.

I considered removing the browser field if it was just the default browser object, so I reduced some duplicate definitions of the default browser fields, but ultimately, I decided against that for simplicity. I left the de-duping though. Obviously, happy to adjust in any way you prefer!