### PR TITLE
Refactor main tachometer runner code into a class

### DIFF
--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -28,17 +28,6 @@ import {Server} from './server';
 import {specUrl} from './specs';
 import {wait} from './util';
 
-function combineResults(results: BenchmarkResult[]): BenchmarkResult {
-  const combined: BenchmarkResult = {
-    ...results[0],
-    millis: [],
-  };
-  for (const result of results) {
-    combined.millis.push(...result.millis);
-  }
-  return combined;
-}
-
 interface Browser {
   name: string;
   driver: webdriver.WebDriver;
@@ -47,36 +36,50 @@ interface Browser {
 
 export class AutomaticMode {
   private config: Config;
+  private specs: BenchmarkSpec[];
   private servers: Map<BenchmarkSpec, Server>;
+  private browsers = new Map<string, Browser>();
+  private bar: ProgressBar;
+  private completeGithubCheck?: (markdown: string) => void;
+  private specResults = new Map<BenchmarkSpec, BenchmarkResult[]>();
+  private hitTimeout = false;
 
   constructor(config: Config, servers: Map<BenchmarkSpec, Server>) {
     this.config = config;
+    this.specs = config.benchmarks;
     this.servers = servers;
+    this.bar = new ProgressBar('[:bar] :status', {
+      total: this.specs.length * (config.sampleSize + /** warmup */ 1),
+      width: 58,
+    });
   }
 
   async run(): Promise<Array<ResultStatsWithDifferences>|undefined> {
-    const {config, servers} = this;
-
-    let completeGithubCheck;
-    if (config.githubCheck !== undefined) {
-      completeGithubCheck = await github.createCheck(config.githubCheck);
+    await this.launchBrowsers();
+    if (this.config.githubCheck !== undefined) {
+      this.completeGithubCheck =
+          await github.createCheck(this.config.githubCheck);
     }
-
     console.log('Running benchmarks\n');
+    await this.warmup();
+    for (const spec of this.specs) {
+      this.specResults.set(spec, []);
+    }
+    await this.takeMinimumSamples();
+    await this.takeAdditionalSamples();
+    await this.closeBrowsers();
+    const results = this.makeResults();
+    await this.outputResults(results);
+    return results;
+  }
 
-    const specs = config.benchmarks;
-    const bar = new ProgressBar('[:bar] :status', {
-      total: specs.length * (config.sampleSize + /** warmup */ 1),
-      width: 58,
-    });
-
-    const browsers = new Map<string, Browser>();
-    for (const {browser} of specs) {
+  private async launchBrowsers() {
+    for (const {browser} of this.specs) {
       const sig = browserSignature(browser);
-      if (browsers.has(sig)) {
+      if (this.browsers.has(sig)) {
         continue;
       }
-      bar.tick(0, {status: `launching ${browser.name}`});
+      this.bar.tick(0, {status: `launching ${browser.name}`});
       // It's important that we execute each benchmark iteration in a new tab.
       // At least in Chrome, each tab corresponds to process which shares some
       // amount of cached V8 state which can cause significant measurement
@@ -87,101 +90,35 @@ export class AutomaticMode {
       const tabs = await driver.getAllWindowHandles();
       // We'll always launch new tabs from this initial blank tab.
       const initialTabHandle = tabs[0];
-      browsers.set(sig, {name: browser.name, driver, initialTabHandle});
+      this.browsers.set(sig, {name: browser.name, driver, initialTabHandle});
     }
+  }
 
-    const runSpec = async(spec: BenchmarkSpec): Promise<BenchmarkResult> => {
-      let server;
-      if (spec.url.kind === 'local') {
-        server = servers.get(spec);
-        if (server === undefined) {
-          throw new Error('Internal error: no server for spec');
-        }
-      }
+  private async closeBrowsers() {
+    // Close the browsers by closing each of their last remaining tabs.
+    await Promise.all(
+        [...this.browsers.values()].map(({driver}) => driver.close()));
+  }
 
-      const url = specUrl(spec, servers, config);
-      const {driver, initialTabHandle} =
-          browsers.get(browserSignature(spec.browser))!;
-
-      let millis: number|undefined;
-      let bytesSent = 0;
-      let userAgent = '';
-      // TODO(aomarks) Make maxAttempts and timeouts configurable.
-      const maxAttempts = 3;
-      for (let attempt = 1;; attempt++) {
-        await openAndSwitchToNewTab(driver, spec.browser);
-        await driver.get(url);
-        for (let waited = 0; millis === undefined && waited <= 10000;
-             waited += 50) {
-          await wait(50);
-          millis = await measure(driver, spec, server);
-        }
-
-        // Close the active tab (but not the whole browser, since the
-        // initial blank tab is still open).
-        await driver.close();
-        await driver.switchTo().window(initialTabHandle);
-
-        if (server !== undefined) {
-          const session = server.endSession();
-          bytesSent = session.bytesSent;
-          userAgent = session.userAgent;
-        }
-
-        if (millis !== undefined || attempt >= maxAttempts) {
-          break;
-        }
-
-        console.log(
-            `\n\nFailed ${attempt}/${maxAttempts} times ` +
-            `to get a ${spec.measurement} measurement ` +
-            (spec.measurement === 'global' ?
-                 `(from '${spec.measurementExpression}') ` :
-                 '') +
-            `in ${spec.browser.name} from ${url}. Retrying.`);
-      }
-
-      if (millis === undefined) {
-        console.log();
-        throw new Error(
-            `\n\nFailed ${maxAttempts}/${maxAttempts} times ` +
-            `to get a ${spec.measurement} measurement ` +
-            (spec.measurement === 'global' ?
-                 `(from '${spec.measurementExpression}') ` :
-                 '') +
-            `in ${spec.browser.name} from ${url}. Retrying.`);
-      }
-
-      return {
-        name: spec.name,
-        queryString: spec.url.kind === 'local' ? spec.url.queryString : '',
-        version: spec.url.kind === 'local' && spec.url.version !== undefined ?
-            spec.url.version.label :
-            '',
-        millis: [millis],
-        bytesSent,
-        browser: spec.browser,
-        userAgent,
-      };
-    };
-
-    // Do one throw-away run per benchmark to warm up our server (especially
-    // when expensive bare module resolution is enabled), and the browser.
+  /**
+   * Do one throw-away run per benchmark to warm up our server (especially
+   * when expensive bare module resolution is enabled), and the browser.
+   */
+  private async warmup() {
+    const {specs, bar} = this;
     for (let i = 0; i < specs.length; i++) {
       const spec = specs[i];
       bar.tick(0, {
         status: `warmup ${i + 1}/${specs.length} ${benchmarkOneLiner(spec)}`,
       });
-      await runSpec(spec);
+      await this.takeSample(spec);
       bar.tick(1);
     }
+  }
 
-    const specResults = new Map<BenchmarkSpec, BenchmarkResult[]>();
-    for (const spec of specs) {
-      specResults.set(spec, []);
-    }
-
+  private async takeMinimumSamples() {
     // Always collect our minimum number of samples.
+    const {config, specs, bar, specResults} = this;
     const numRuns = specs.length * config.sampleSize;
     let run = 0;
     for (let sample = 0; sample < config.sampleSize; sample++) {
@@ -189,7 +126,7 @@ export class AutomaticMode {
         bar.tick(0, {
           status: `${++run}/${numRuns} ${benchmarkOneLiner(spec)}`,
         });
-        specResults.get(spec)!.push(await runSpec(spec));
+        specResults.get(spec)!.push(await this.takeSample(spec));
         if (bar.curr === bar.total - 1) {
           // Note if we tick with 0 after we've completed, the status is
           // rendered on the next line for some reason.
@@ -199,20 +136,10 @@ export class AutomaticMode {
         }
       }
     }
+  }
 
-    const makeResults = () => {
-      const results: BenchmarkResult[] = [];
-      for (const sr of specResults.values()) {
-        results.push(combineResults(sr));
-      }
-      const withStats = results.map((result): ResultStats => ({
-                                      result,
-                                      stats: summaryStats(result.millis),
-                                    }));
-      return computeDifferences(withStats);
-    };
-
-    let hitTimeout = false;
+  private async takeAdditionalSamples() {
+    const {config, specs, specResults} = this;
     if (config.timeout > 0) {
       console.log();
       const timeoutMs = config.timeout * 60 * 1000;  // minutes -> millis
@@ -221,12 +148,12 @@ export class AutomaticMode {
       let sample = 0;
       let elapsed = 0;
       while (true) {
-        if (horizonsResolved(makeResults(), config.horizons)) {
+        if (horizonsResolved(this.makeResults(), config.horizons)) {
           console.log();
           break;
         }
         if (elapsed >= timeoutMs) {
-          hitTimeout = true;
+          this.hitTimeout = true;
           break;
         }
         // Run batches of 10 additional samples at a time for more presentable
@@ -243,16 +170,111 @@ export class AutomaticMode {
             process.stdout.write(
                 `\r${spinner[run % spinner.length]} Auto-sample ${sample} ` +
                 `(timeout in ${mins}m${secs}s)` + ansi.erase.inLine(0));
-            specResults.get(spec)!.push(await runSpec(spec));
+            specResults.get(spec)!.push(await this.takeSample(spec));
           }
         }
       }
     }
+  }
 
-    // Close the browsers by closing each of their last remaining tabs.
-    await Promise.all([...browsers.values()].map(({driver}) => driver.close()));
+  private async takeSample(spec: BenchmarkSpec): Promise<BenchmarkResult> {
+    const {servers, config, browsers} = this;
 
-    const withDifferences = makeResults();
+    let server;
+    if (spec.url.kind === 'local') {
+      server = servers.get(spec);
+      if (server === undefined) {
+        throw new Error('Internal error: no server for spec');
+      }
+    }
+
+    const url = specUrl(spec, servers, config);
+    const {driver, initialTabHandle} =
+        browsers.get(browserSignature(spec.browser))!;
+
+    let millis: number|undefined;
+    let bytesSent = 0;
+    let userAgent = '';
+    // TODO(aomarks) Make maxAttempts and timeouts configurable.
+    const maxAttempts = 3;
+    for (let attempt = 1;; attempt++) {
+      await openAndSwitchToNewTab(driver, spec.browser);
+      await driver.get(url);
+      for (let waited = 0; millis === undefined && waited <= 10000;
+           waited += 50) {
+        await wait(50);
+        millis = await measure(driver, spec, server);
+      }
+
+      // Close the active tab (but not the whole browser, since the
+      // initial blank tab is still open).
+      await driver.close();
+      await driver.switchTo().window(initialTabHandle);
+
+      if (server !== undefined) {
+        const session = server.endSession();
+        bytesSent = session.bytesSent;
+        userAgent = session.userAgent;
+      }
+
+      if (millis !== undefined || attempt >= maxAttempts) {
+        break;
+      }
+
+      console.log(
+          `\n\nFailed ${attempt}/${maxAttempts} times ` +
+          `to get a ${spec.measurement} measurement ` +
+          (spec.measurement === 'global' ?
+               `(from '${spec.measurementExpression}') ` :
+               '') +
+          `in ${spec.browser.name} from ${url}. Retrying.`);
+    }
+
+    if (millis === undefined) {
+      console.log();
+      throw new Error(
+          `\n\nFailed ${maxAttempts}/${maxAttempts} times ` +
+          `to get a ${spec.measurement} measurement ` +
+          (spec.measurement === 'global' ?
+               `(from '${spec.measurementExpression}') ` :
+               '') +
+          `in ${spec.browser.name} from ${url}. Retrying.`);
+    }
+
+    return {
+      name: spec.name,
+      queryString: spec.url.kind === 'local' ? spec.url.queryString : '',
+      version: spec.url.kind === 'local' && spec.url.version !== undefined ?
+          spec.url.version.label :
+          '',
+      millis: [millis],
+      bytesSent,
+      browser: spec.browser,
+      userAgent,
+    };
+  }
+
+  makeResults() {
+    const results: BenchmarkResult[] = [];
+    for (const sr of this.specResults.values()) {
+      const combined: BenchmarkResult = {
+        ...sr[0],
+        millis: [],
+      };
+      for (const result of sr) {
+        combined.millis.push(...result.millis);
+      }
+      results.push(combined);
+    }
+    const withStats = results.map((result): ResultStats => ({
+                                    result,
+                                    stats: summaryStats(result.millis),
+                                  }));
+    return computeDifferences(withStats);
+  }
+
+  private async outputResults(withDifferences: ResultStatsWithDifferences[]) {
+    const {config, hitTimeout} = this;
     console.log();
     const {fixed, unfixed} = automaticResultTable(withDifferences);
     console.log(horizontalTermResultTable(fixed));
@@ -284,12 +306,10 @@ export class AutomaticMode {
       await fsExtra.writeFile(config.csvFileRaw, formatCsvRaw(withDifferences));
     }
 
-    if (completeGithubCheck !== undefined) {
+    if (this.completeGithubCheck !== undefined) {
       const markdown = horizontalHtmlResultTable(fixed) + '\n' +
           verticalHtmlResultTable(unfixed);
-      await completeGithubCheck(markdown);
+      await this.completeGithubCheck(markdown);
     }
-
-    return withDifferences;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ import {Server} from './server';
 import {ResultStatsWithDifferences} from './stats';
 import {prepareVersionDirectory, makeServerPlans} from './versions';
 import {manualMode} from './manual';
-import {automaticMode} from './automatic';
+import {AutomaticMode} from './automatic';
 import {runNpm} from './util';
 
 const installedVersion = (): string =>
@@ -150,8 +150,9 @@ $ tach http://example.com
     await manualMode(config, servers);
 
   } else {
+    const runner = new AutomaticMode(config, servers);
     try {
-      return await automaticMode(config, servers);
+      return await runner.run();
     } finally {
       const allServers = new Set<Server>([...servers.values()]);
       await Promise.all([...allServers].map((server) => server.close()));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ import {Server} from './server';
 import {ResultStatsWithDifferences} from './stats';
 import {prepareVersionDirectory, makeServerPlans} from './versions';
 import {manualMode} from './manual';
-import {AutomaticMode} from './automatic';
+import {Runner} from './runner';
 import {runNpm} from './util';
 
 const installedVersion = (): string =>
@@ -150,7 +150,7 @@ $ tach http://example.com
     await manualMode(config, servers);
 
   } else {
-    const runner = new AutomaticMode(config, servers);
+    const runner = new Runner(config, servers);
     try {
       return await runner.run();
     } finally {


### PR DESCRIPTION
The main tachometer runner logic had gotten pretty hard to read. It still could be better, but this PR refactors it into a class as a start on some better organization. No behavioral changes here, just moving existing code around into methods.