### PR TITLE
Improve representation of measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,26 @@ project adheres to [Semantic Versioning](http://semver.org/).
   "benchmarks": [
     {
       "measurement": {
-        "performanceEntry": {
-          "name": "foo"
-        }
+        "kind": "performance",
+        "entryName": "foo"
+      }
+    }
+  ]
+  ```
+
+- Add new syntax for specifying benchmarks:
+
+  ```
+  "benchmarks": [
+    {
+      "measurement": {
+        "kind": "callback"
+      }
+    },
+    {
+      "measurement": {
+        "kind": "expression",
+        "expression": "window.tachometerResult"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ And in your config file:
 "benchmarks": [
   {
     "measurement": {
-      "performanceEntry": {
-        "name": "foo"
-      }
+      "kind": "performance",
+      "entryName": "foo"
     }
   }
 ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,6 +2,21 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
+        "CallbackMeasurement": {
+            "additionalProperties": false,
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "callback"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "kind"
+            ],
+            "type": "object"
+        },
         "ChromeConfig": {
             "additionalProperties": false,
             "properties": {
@@ -90,16 +105,13 @@
                 "measurement": {
                     "anyOf": [
                         {
-                            "additionalProperties": false,
-                            "properties": {
-                                "performanceEntry": {
-                                    "$ref": "#/definitions/PerformanceEntryCriteria"
-                                }
-                            },
-                            "required": [
-                                "performanceEntry"
-                            ],
-                            "type": "object"
+                            "$ref": "#/definitions/CallbackMeasurement"
+                        },
+                        {
+                            "$ref": "#/definitions/PerformanceEntryMeasurement"
+                        },
+                        {
+                            "$ref": "#/definitions/ExpressionMeasurement"
                         },
                         {
                             "enum": [
@@ -170,6 +182,25 @@
             },
             "required": [
                 "name"
+            ],
+            "type": "object"
+        },
+        "ExpressionMeasurement": {
+            "additionalProperties": false,
+            "properties": {
+                "expression": {
+                    "type": "string"
+                },
+                "kind": {
+                    "enum": [
+                        "expression"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "expression",
+                "kind"
             ],
             "type": "object"
         },
@@ -254,16 +285,22 @@
             "description": "A mapping from NPM package name to version specifier, as used in a\npackage.json's \"dependencies\" and \"devDependencies\".",
             "type": "object"
         },
-        "PerformanceEntryCriteria": {
+        "PerformanceEntryMeasurement": {
             "additionalProperties": false,
-            "description": "Criteria for matching a Performance Entry.",
             "properties": {
-                "name": {
+                "entryName": {
+                    "type": "string"
+                },
+                "kind": {
+                    "enum": [
+                        "performance"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "name"
+                "entryName",
+                "kind"
             ],
             "type": "object"
         },

--- a/src/automatic.ts
+++ b/src/automatic.ts
@@ -202,8 +202,9 @@ export class AutomaticMode {
       await driver.get(url);
       for (let waited = 0; millis === undefined && waited <= 10000;
            waited += 50) {
+        // TODO(aomarks) You don't have to wait in callback mode!
         await wait(50);
-        millis = await measure(driver, spec, server);
+        millis = await measure(driver, spec.measurement, server);
       }
 
       // Close the active tab (but not the whole browser, since the
@@ -223,10 +224,7 @@ export class AutomaticMode {
 
       console.log(
           `\n\nFailed ${attempt}/${maxAttempts} times ` +
-          `to get a ${spec.measurement} measurement ` +
-          (spec.measurement === 'global' ?
-               `(from '${spec.measurementExpression}') ` :
-               '') +
+          `to get a measurement ` +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }
 
@@ -234,10 +232,7 @@ export class AutomaticMode {
       console.log();
       throw new Error(
           `\n\nFailed ${maxAttempts}/${maxAttempts} times ` +
-          `to get a ${spec.measurement} measurement ` +
-          (spec.measurement === 'global' ?
-               `(from '${spec.measurementExpression}') ` :
-               '') +
+          `to get a measurement ` +
           `in ${spec.browser.name} from ${url}. Retrying.`);
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,7 +123,9 @@ export async function makeConfig(opts: Opts): Promise<Config> {
   }
 
   for (const spec of config.benchmarks) {
-    if (spec.measurement === 'fcp' && !fcpBrowsers.has(spec.browser.name)) {
+    if (spec.measurement.kind === 'performance' &&
+        spec.measurement.entryName === 'first-contentful-paint' &&
+        !fcpBrowsers.has(spec.browser.name)) {
       throw new Error(
           `Browser ${spec.browser.name} does not support the ` +
           `first contentful paint (FCP) measurement`);

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -114,7 +114,7 @@ interface ConfigFileBenchmark {
    *       }
    *     }
    */
-  measurement?: Measurement;
+  measurement?: ConfigFileMeasurement;
 
   /**
    * Expression to use to retrieve global result.  Defaults to
@@ -135,6 +135,8 @@ interface ConfigFileBenchmark {
    */
   expand?: ConfigFileBenchmark[];
 }
+
+type ConfigFileMeasurement = 'callback'|'fcp'|'global'|Measurement;
 
 type BrowserConfigs =
     ChromeConfig|FirefoxConfig|SafariConfig|EdgeConfig|IEConfig;
@@ -324,12 +326,23 @@ async function parseBenchmark(benchmark: ConfigFileBenchmark, root: string):
     spec.browser = browser;
   }
 
-  if (benchmark.measurement !== undefined) {
+  if (benchmark.measurement === 'callback') {
+    spec.measurement = {
+      kind: 'callback',
+    };
+  } else if (benchmark.measurement === 'fcp') {
+    spec.measurement = {
+      kind: 'performance',
+      entryName: 'first-contentful-paint',
+    };
+  } else if (benchmark.measurement === 'global') {
+    spec.measurement = {
+      kind: 'expression',
+      expression:
+          benchmark.measurementExpression || defaults.measurementExpression,
+    };
+  } else {
     spec.measurement = benchmark.measurement;
-  }
-  if (spec.measurement === 'global' &&
-      benchmark.measurementExpression !== undefined) {
-    spec.measurementExpression = benchmark.measurementExpression;
   }
 
   const url = benchmark.url;
@@ -446,15 +459,7 @@ function applyDefaults(partialSpec: Partial<BenchmarkSpec>): BenchmarkSpec {
   if (measurement === undefined) {
     measurement = defaults.measurement(url);
   }
-  const spec: BenchmarkSpec = {name, url, browser, measurement};
-  if (measurement === 'global') {
-    if (partialSpec.measurementExpression === undefined) {
-      spec.measurementExpression = defaults.measurementExpression;
-    } else {
-      spec.measurementExpression = partialSpec.measurementExpression;
-    }
-  }
-  return spec;
+  return {name, url, browser, measurement};
 }
 
 export async function writeBackSchemaIfNeeded(

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -27,7 +27,10 @@ export const measurementExpression = 'window.tachometerResult';
 
 export function measurement(url: LocalUrl|RemoteUrl): Measurement {
   if (url.kind === 'remote') {
-    return 'fcp';
+    return {
+      kind: 'performance',
+      entryName: 'first-contentful-paint',
+    };
   }
-  return 'callback';
+  return {kind: 'callback'};
 }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 
 import {supportedBrowsers} from './browser';
 import * as defaults from './defaults';
-import {Measurement, measurements} from './types';
+import {CommandLineMeasurements, measurements} from './types';
 
 import commandLineArgs = require('command-line-args');
 import commandLineUsage = require('command-line-usage');
@@ -216,7 +216,7 @@ export interface Opts {
   'sample-size': number|undefined;
   manual: boolean;
   save: string;
-  measure: Measurement|undefined;
+  measure: CommandLineMeasurements|undefined;
   'measurement-expression': string|undefined;
   horizon: string|undefined;
   timeout: number|undefined;

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -12,7 +12,7 @@
 import * as webdriver from 'selenium-webdriver';
 
 import {Server} from './server';
-import {BenchmarkSpec, PerformanceEntryCriteria} from './types';
+import {Measurement, PerformanceEntryMeasurement} from './types';
 import {escapeStringLiteral, throwUnreachable} from './util';
 
 /**
@@ -22,25 +22,18 @@ import {escapeStringLiteral, throwUnreachable} from './util';
  */
 export async function measure(
     driver: webdriver.WebDriver,
-    {measurement, measurementExpression}: BenchmarkSpec,
+    measurement: Measurement,
     server: Server|undefined): Promise<number|undefined> {
-  if (measurement === 'fcp') {
-    return queryForPerformanceEntry(driver, {name: 'first-contentful-paint'});
-  }
-  if (measurement === 'callback') {
-    if (server === undefined) {
-      throw new Error('Internal error: no server for spec');
-    }
-    return (await server.nextResults()).millis;
-  }
-  if (measurement === 'global') {
-    if (!measurementExpression) {
-      throw new Error('Internal error: no measurement expression');
-    }
-    return queryForExpression(driver, measurementExpression);
-  }
-  if (measurement && 'performanceEntry' in measurement) {
-    return queryForPerformanceEntry(driver, measurement.performanceEntry);
+  switch (measurement.kind) {
+    case 'callback':
+      if (server === undefined) {
+        throw new Error('Internal error: no server for spec');
+      }
+      return (await server.nextResults()).millis;
+    case 'expression':
+      return queryForExpression(driver, measurement.expression);
+    case 'performance':
+      return queryForPerformanceEntry(driver, measurement);
   }
   throwUnreachable(
       measurement,
@@ -71,8 +64,8 @@ interface PerformanceEntry {
  */
 async function queryForPerformanceEntry(
     driver: webdriver.WebDriver,
-    criteria: PerformanceEntryCriteria): Promise<number|undefined> {
-  const escaped = escapeStringLiteral(criteria.name);
+    measurement: PerformanceEntryMeasurement): Promise<number|undefined> {
+  const escaped = escapeStringLiteral(measurement.entryName);
   const script = `return window.performance.getEntriesByName(\`${escaped}\`);`;
   const entries = await driver.executeScript(script) as PerformanceEntry[];
   if (entries.length === 0) {

--- a/src/test/config_test.ts
+++ b/src/test/config_test.ts
@@ -60,7 +60,9 @@ suite('makeConfig', function() {
               width: 1024,
             },
           },
-          measurement: 'callback',
+          measurement: {
+            kind: 'callback',
+          },
           name: 'random-global.html',
           url: {
             kind: 'local',
@@ -101,7 +103,9 @@ suite('makeConfig', function() {
               width: 1024,
             },
           },
-          measurement: 'callback',
+          measurement: {
+            kind: 'callback',
+          },
           // TODO(aomarks) Why does this have a forward-slash?
           name: '/random-global.html',
           url: {
@@ -142,7 +146,9 @@ suite('makeConfig', function() {
               width: 1024,
             },
           },
-          measurement: 'callback',
+          measurement: {
+            kind: 'callback',
+          },
           // TODO(aomarks) Why does this have a forward-slash?
           name: '/random-global.html',
           url: {
@@ -190,7 +196,9 @@ suite('makeConfig', function() {
               width: 1024,
             },
           },
-          measurement: 'callback',
+          measurement: {
+            kind: 'callback',
+          },
           // TODO(aomarks) Why does this have a forward-slash?
           name: '/random-global.html',
           url: {

--- a/src/test/configfile_test.ts
+++ b/src/test/configfile_test.ts
@@ -54,7 +54,10 @@ suite('config', () => {
           {
             name: 'remote',
             browser: defaultBrowser,
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             url: 'http://example.com?foo=bar',
           },
           {
@@ -66,7 +69,7 @@ suite('config', () => {
                 'layout.css.shadow-parts.enabled': true,
               },
             },
-            measurement: 'callback',
+            measurement: {kind: 'callback'},
             url: 'mybench/index.html?foo=bar',
             packageVersions: {
               label: 'master',
@@ -83,7 +86,10 @@ suite('config', () => {
               name: 'chrome',
               cpuThrottlingRate: 6,
             },
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             url: 'http://example.com?foo=bar',
           },
         ],
@@ -101,7 +107,10 @@ suite('config', () => {
           {
             name: 'remote',
             browser: defaultBrowser,
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             url: {
               kind: 'remote',
               url: 'http://example.com?foo=bar',
@@ -116,7 +125,7 @@ suite('config', () => {
                 'layout.css.shadow-parts.enabled': true,
               },
             },
-            measurement: 'callback',
+            measurement: {kind: 'callback'},
             url: {
               kind: 'local',
               urlPath: '/mybench/index.html',
@@ -137,7 +146,10 @@ suite('config', () => {
               name: 'chrome',
               cpuThrottlingRate: 6,
             },
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             url: {
               kind: 'remote',
               url: 'http://example.com?foo=bar',
@@ -173,7 +185,10 @@ suite('config', () => {
               kind: 'remote',
               url: 'http://example.com?foo=bar',
             },
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             browser: defaultBrowser,
           },
           {
@@ -183,7 +198,83 @@ suite('config', () => {
               urlPath: '/mybench/index.html',
               queryString: '?foo=bar',
             },
-            measurement: 'callback',
+            measurement: {kind: 'callback'},
+            browser: defaultBrowser,
+          },
+        ],
+      };
+      const actual = await parseConfigFile(config);
+      assert.deepEqual(actual, expected);
+    });
+
+    test('object-style measurement specifications', async () => {
+      const config = {
+        benchmarks: [
+          {
+            url: 'mybench/index.html?foo=a',
+            measurement: {
+              kind: 'callback',
+            }
+          },
+          {
+            url: 'mybench/index.html?foo=b',
+            measurement: {
+              kind: 'expression',
+              expression: 'window.foo',
+            }
+          },
+          {
+            url: 'mybench/index.html?foo=c',
+            measurement: {
+              kind: 'performance',
+              entryName: 'foo-measure',
+            }
+          },
+        ],
+      };
+      const expected: Partial<Config> = {
+        root: '.',
+        sampleSize: undefined,
+        timeout: undefined,
+        horizons: undefined,
+        resolveBareModules: undefined,
+        benchmarks: [
+          {
+            name: '/mybench/index.html?foo=a',
+            url: {
+              kind: 'local',
+              urlPath: '/mybench/index.html',
+              queryString: '?foo=a',
+            },
+            measurement: {
+              kind: 'callback',
+            },
+            browser: defaultBrowser,
+          },
+          {
+            name: '/mybench/index.html?foo=b',
+            url: {
+              kind: 'local',
+              urlPath: '/mybench/index.html',
+              queryString: '?foo=b',
+            },
+            measurement: {
+              kind: 'expression',
+              expression: 'window.foo',
+            },
+            browser: defaultBrowser,
+          },
+          {
+            name: '/mybench/index.html?foo=c',
+            url: {
+              kind: 'local',
+              urlPath: '/mybench/index.html',
+              queryString: '?foo=c',
+            },
+            measurement: {
+              kind: 'performance',
+              entryName: 'foo-measure',
+            },
             browser: defaultBrowser,
           },
         ],
@@ -199,14 +290,17 @@ suite('config', () => {
           url: 'http://example.com',
           expand: [
             {
-              measurement: 'fcp',
+              measurement: {
+                kind: 'performance',
+                entryName: 'first-contentful-paint',
+              },
               expand: [
                 {browser: 'chrome'},
                 {browser: 'firefox'},
               ],
             },
             {
-              measurement: 'callback',
+              measurement: {kind: 'callback'},
               expand: [
                 {browser: 'chrome'},
                 {browser: 'firefox'},
@@ -225,13 +319,19 @@ suite('config', () => {
           {
             name: 'http://example.com',
             url: {kind: 'remote', url: 'http://example.com'},
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             browser: defaultBrowser,
           },
           {
             name: 'http://example.com',
             url: {kind: 'remote', url: 'http://example.com'},
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             browser: {
               ...defaultBrowser,
               name: 'firefox',
@@ -240,13 +340,13 @@ suite('config', () => {
           {
             name: 'http://example.com',
             url: {kind: 'remote', url: 'http://example.com'},
-            measurement: 'callback',
+            measurement: {kind: 'callback'},
             browser: defaultBrowser,
           },
           {
             name: 'http://example.com',
             url: {kind: 'remote', url: 'http://example.com'},
-            measurement: 'callback',
+            measurement: {kind: 'callback'},
             browser: {
               ...defaultBrowser,
               name: 'firefox',
@@ -289,7 +389,10 @@ suite('config', () => {
               kind: 'remote',
               url: 'http://example.com?foo=bar',
             },
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
             browser: {
               name: 'chrome',
               headless: false,
@@ -388,7 +491,10 @@ suite('config', () => {
         const config = {
           benchmarks: [{
             browser: 'chrome',
-            measurement: 'fcp',
+            measurement: {
+              kind: 'performance',
+              entryName: 'first-contentful-paint',
+            },
           }],
         };
         await assert.isRejected(parseConfigFile(config), /no url specified/i);

--- a/src/test/data/performance-measure.json
+++ b/src/test/data/performance-measure.json
@@ -1,33 +1,31 @@
 {
-    "$schema": "https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json",
-    "sampleSize": 10,
-    "timeout": 0,
-    "benchmarks": [
-        {
-            "name": "20",
-            "url": "src/test/data/performance-measure.html?wait=20",
-            "measurement": {
-              "performanceEntry": {
-                "name": "foo"
-              }
-            },
-            "browser": {
-                "name": "chrome",
-                "headless": true
-            }
-        },
-        {
-            "name": "60",
-            "url": "src/test/data/performance-measure.html?wait=60",
-            "measurement": {
-              "performanceEntry": {
-                "name": "foo"
-              }
-            },
-            "browser": {
-                "name": "chrome",
-                "headless": true
-            }
-        }
-    ]
+  "$schema": "https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json",
+  "sampleSize": 10,
+  "timeout": 0,
+  "benchmarks": [
+    {
+      "name": "20",
+      "url": "src/test/data/performance-measure.html?wait=20",
+      "measurement": {
+        "kind": "performance",
+        "entryName": "foo"
+      },
+      "browser": {
+        "name": "chrome",
+        "headless": true
+      }
+    },
+    {
+      "name": "60",
+      "url": "src/test/data/performance-measure.html?wait=60",
+      "measurement": {
+        "kind": "performance",
+        "entryName": "foo"
+      },
+      "browser": {
+        "name": "chrome",
+        "headless": true
+      }
+    }
+  ]
 }

--- a/src/test/specs_test.ts
+++ b/src/test/specs_test.ts
@@ -65,7 +65,10 @@ suite('specsFromOpts', () => {
           url: 'http://example.com',
         },
         browser: defaultBrowser,
-        measurement: 'fcp',
+        measurement: {
+          kind: 'performance',
+          entryName: 'first-contentful-paint',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -82,7 +85,10 @@ suite('specsFromOpts', () => {
           url: 'http://example.com',
         },
         browser: defaultBrowser,
-        measurement: 'fcp',
+        measurement: {
+          kind: 'performance',
+          entryName: 'first-contentful-paint',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -101,7 +107,9 @@ suite('specsFromOpts', () => {
           version: undefined,
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -120,7 +128,9 @@ suite('specsFromOpts', () => {
           version: undefined,
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -139,7 +149,9 @@ suite('specsFromOpts', () => {
           version: undefined,
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -158,7 +170,9 @@ suite('specsFromOpts', () => {
           version: undefined,
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -177,7 +191,9 @@ suite('specsFromOpts', () => {
           version: undefined,
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -196,7 +212,9 @@ suite('specsFromOpts', () => {
           version: undefined,
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);
@@ -224,7 +242,9 @@ suite('specsFromOpts', () => {
           },
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
       {
         name: 'mybench',
@@ -240,7 +260,9 @@ suite('specsFromOpts', () => {
           },
         },
         browser: defaultBrowser,
-        measurement: 'callback',
+        measurement: {
+          kind: 'callback',
+        },
       },
     ];
     assert.deepEqual(actual, expected);

--- a/src/test/versions_test.ts
+++ b/src/test/versions_test.ts
@@ -45,7 +45,10 @@ suite('versions', () => {
             },
             queryString: '',
           },
-          measurement: 'fcp',
+          measurement: {
+            kind: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: defaultBrowser,
         },
         {
@@ -61,7 +64,10 @@ suite('versions', () => {
             },
             queryString: '',
           },
-          measurement: 'fcp',
+          measurement: {
+            kind: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: defaultBrowser,
         },
 
@@ -73,7 +79,10 @@ suite('versions', () => {
             urlPath: '/mylib/mybench/',
             queryString: '',
           },
-          measurement: 'fcp',
+          measurement: {
+            kind: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: defaultBrowser,
         },
         {
@@ -83,7 +92,10 @@ suite('versions', () => {
             urlPath: '/otherlib/otherbench/',
             queryString: '',
           },
-          measurement: 'fcp',
+          measurement: {
+            kind: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: defaultBrowser,
         },
 
@@ -94,7 +106,10 @@ suite('versions', () => {
             kind: 'remote',
             url: 'http://example.com',
           },
-          measurement: 'fcp',
+          measurement: {
+            kind: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: defaultBrowser,
         },
       ];
@@ -189,7 +204,10 @@ suite('versions', () => {
             },
             queryString: '',
           },
-          measurement: 'fcp',
+          measurement: {
+            kind: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: defaultBrowser,
         },
       ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,20 +49,30 @@ export interface NpmPackageJson {
 
 /** The kinds of intervals we can measure. */
 export type Measurement =
-    'callback'|'fcp'|'global'|{performanceEntry: PerformanceEntryCriteria};
+    CallbackMeasurement|PerformanceEntryMeasurement|ExpressionMeasurement;
+
+export interface CallbackMeasurement {
+  kind: 'callback';
+}
+
+export interface PerformanceEntryMeasurement {
+  kind: 'performance';
+  entryName: string;
+}
+
+export interface ExpressionMeasurement {
+  kind: 'expression';
+  expression: string;
+}
+
+export type CommandLineMeasurements = 'callback'|'fcp'|'global';
 
 export const measurements = new Set<string>(['callback', 'fcp', 'global']);
-
-/** Criteria for matching a Performance Entry. */
-export interface PerformanceEntryCriteria {
-  name: string;
-}
 
 /** A specification of a benchmark to run. */
 export interface BenchmarkSpec {
   url: LocalUrl|RemoteUrl;
   measurement: Measurement;
-  measurementExpression?: string;
   name: string;
   browser: BrowserConfig;
 }


### PR DESCRIPTION
This PR updates the internal representation of measurement types in the benchmark "spec" interface, and also adds a matching syntax that can now be used in the config file.

This is partly prep work for the next upcoming PR, which will allow specifying an *array* of measurements to take for each benchmark URL.