### PR TITLE
Prefer __dirname over module.path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-  - "node"
+node_js: '10'
 script:
   - npm test
 addons:

--- a/src/install.ts
+++ b/src/install.ts
@@ -49,7 +49,13 @@ export interface ContainsOnDemandDependencies {
 }
 
 export const getPackageJSONPath = async(): Promise<string|null> => {
-  return pkgUp({cwd: module.path});
+  // NOTE: This used to search starting with module.path, but module.path was
+  // not added until Node.js v11. In order to preserve Node.js v10 compatibility
+  // we use __dirname instead, which should be mostly the same thing (docs are
+  // fuzzy on the specific differences, unfortunately).
+  // @see https://nodejs.org/docs/latest/api/modules.html#modules_module_path
+  // @see https://nodejs.org/docs/latest/api/modules.html#modules_dirname
+  return pkgUp({cwd: __dirname});
 };
 
 export const getPackageRoot = async(): Promise<string|null> => {


### PR DESCRIPTION
...for the sake of Node.js v10 compatibility

In Node.js v10, `module.path` is `undefined` so the `package.json` is resolved starting from the process's current working directory rather than Tachometer's install location. We don't allow on-demand installation of non-`devDependencies`, and the installation fails if `chromedriver` (et al) is not found in the ultimately resolved `package.json`.

Fixes #182 