### PR TITLE
Add measurement object to JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Add `name` property to measurement config
+- Include `measurement` object for each benchmark in JSON results output
 
 ## [0.5.1] 2020-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- Add `name` property to measurement config
+- Add support for `name` property to measurement config
 - Include `measurement` object for each benchmark in JSON results output
 
 ## [0.5.1] 2020-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Add `name` property to measurement config
 
 ## [0.5.1] 2020-08-19
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ If `measurement` is an array, then all of the given measurements will be
 retrieved from each page load. Each measurement from a page is treated as its
 own benchmark.
 
+A measurement can specify a `name` property that will be used to display its
+results.
+
 #### Performance API
 
 Retrieve a measure, mark, or paint timing from the

--- a/config.schema.json
+++ b/config.schema.json
@@ -10,6 +10,9 @@
                         "callback"
                     ],
                     "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -212,6 +215,9 @@
                         "expression"
                     ],
                     "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -311,6 +317,9 @@
                     "enum": [
                         "performance"
                     ],
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             },

--- a/src/json-output.ts
+++ b/src/json-output.ts
@@ -13,7 +13,7 @@ import * as systeminformation from 'systeminformation';
 
 import {BrowserConfig} from './browser';
 import {ResultStatsWithDifferences} from './stats';
-import {BenchmarkResult} from './types';
+import {BenchmarkResult, Measurement} from './types';
 
 export interface JsonOutputFile {
   benchmarks: Benchmark[];
@@ -27,6 +27,7 @@ interface Benchmark {
   name: string;
   bytesSent: number;
   version?: string;
+  measurement: Measurement;
   browser?: BrowserConfigResult;
   mean: ConfidenceInterval;
   differences: Array<Difference|null>;
@@ -68,6 +69,7 @@ export function jsonOutput(results: ResultStatsWithDifferences[]):
       name: result.result.name,
       bytesSent: result.result.bytesSent,
       version: result.result.version ? result.result.version : undefined,
+      measurement: result.result.measurement,
       browser: {
         ...result.result.browser,
         userAgent: result.result.userAgent,

--- a/src/json-output.ts
+++ b/src/json-output.ts
@@ -12,6 +12,7 @@
 import * as systeminformation from 'systeminformation';
 
 import {BrowserConfig} from './browser';
+import {measurementName} from './measure';
 import {ResultStatsWithDifferences} from './stats';
 import {BenchmarkResult, Measurement} from './types';
 
@@ -69,7 +70,10 @@ export function jsonOutput(results: ResultStatsWithDifferences[]):
       name: result.result.name,
       bytesSent: result.result.bytesSent,
       version: result.result.version ? result.result.version : undefined,
-      measurement: result.result.measurement,
+      measurement: {
+        name: measurementName(result.result.measurement),
+        ...result.result.measurement
+      },
       browser: {
         ...result.result.browser,
         userAgent: result.result.userAgent,

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -125,6 +125,10 @@ function escapeStringLiteral(unescaped: string): string {
  * where there are multiple measurements on the same page.
  */
 export function measurementName(measurement: Measurement): string {
+  if (measurement.name) {
+    return measurement.name;
+  }
+
   switch (measurement.mode) {
     case 'callback':
       return 'callback';

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -314,6 +314,7 @@ export class Runner {
           name: spec.measurement.length === 1 ?
               spec.name :
               `${spec.name} [${measurementName(measurement)}]`,
+          measurement,
           measurementIndex: measurementIndex,
           queryString: spec.url.kind === 'local' ? spec.url.queryString : '',
           version: spec.url.kind === 'local' && spec.url.version !== undefined ?

--- a/src/test/e2e_test.ts
+++ b/src/test/e2e_test.ts
@@ -60,39 +60,41 @@ suite('e2e', function() {
   for (const browser of browsers) {
     suite(browser, function() {
       test('window.tachometerResult', hideOutput(async function() {
-        const avgA = 1;
-        const minA = avgA - 0.1;
-        const maxA = avgA + 0.1;
+             const avgA = 1;
+             const minA = avgA - 0.1;
+             const maxA = avgA + 0.1;
 
-        const avgB = 2;
-        const minB = avgB - 0.1;
-        const maxB = avgB + 0.1;
+             const avgB = 2;
+             const minB = avgB - 0.1;
+             const maxB = avgB + 0.1;
 
-        const argv = [
-          `--browser=${browser}`,
-          '--measure=global',
-          '--sample-size=20',
-          '--timeout=0',
-          path.join(testData, 'random-global.html') +
-              `?min=${minA}&max=${maxA}`,
-          path.join(testData, 'random-global.html') +
-              `?min=${minB}&max=${maxB}`,
-        ];
+             const argv = [
+               `--browser=${browser}`,
+               '--measure=global',
+               '--sample-size=20',
+               '--timeout=0',
+               path.join(testData, 'random-global.html') +
+                   `?min=${minA}&max=${maxA}`,
+               path.join(testData, 'random-global.html') +
+                   `?min=${minB}&max=${maxB}`,
+             ];
 
-        const actual = await main(argv);
-        assert.isDefined(actual);
-        assert.lengthOf(actual!, 2);
-        const [a, b] = actual!;
-        const diffAB = a.differences[1]!;
-        const diffBA = b.differences[0]!;
+             const actual = await main(argv);
+             assert.isDefined(actual);
+             assert.lengthOf(actual!, 2);
+             const [a, b] = actual!;
+             const diffAB = a.differences[1]!;
+             const diffBA = b.differences[0]!;
 
-        assert.closeTo(a.stats.mean, avgA, 0.1);
-        assert.closeTo(b.stats.mean, avgB, 0.1);
-        assert.closeTo(ciAverage(diffAB.absolute), avgA - avgB, 0.1);
-        assert.closeTo(ciAverage(diffBA.absolute), avgB - avgA, 0.1);
-        assert.closeTo(ciAverage(diffAB.relative), (avgA - avgB) / avgB, 0.1);
-        assert.closeTo(ciAverage(diffBA.relative), (avgB - avgA) / avgA, 0.1);
-      }));
+             assert.closeTo(a.stats.mean, avgA, 0.1);
+             assert.closeTo(b.stats.mean, avgB, 0.1);
+             assert.closeTo(ciAverage(diffAB.absolute), avgA - avgB, 0.1);
+             assert.closeTo(ciAverage(diffBA.absolute), avgB - avgA, 0.1);
+             assert.closeTo(
+                 ciAverage(diffAB.relative), (avgA - avgB) / avgB, 0.1);
+             assert.closeTo(
+                 ciAverage(diffBA.relative), (avgB - avgA) / avgA, 0.1);
+           }));
 
       test('measurement expression', hideOutput(async function() {
              const avgA = 1;

--- a/src/test/json-output_test.ts
+++ b/src/test/json-output_test.ts
@@ -64,6 +64,10 @@ suite('jsonOutput', () => {
           name: 'foo',
           bytesSent: 1024,
           version: undefined,
+          measurement: {
+            mode: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: {
             name: 'chrome',
             headless: false,
@@ -97,6 +101,10 @@ suite('jsonOutput', () => {
           name: 'bar',
           bytesSent: 2048,
           version: undefined,
+          measurement: {
+            mode: 'performance',
+            entryName: 'first-contentful-paint',
+          },
           browser: {
             name: 'chrome',
             headless: false,
@@ -122,6 +130,181 @@ suite('jsonOutput', () => {
                 low: 67.90324,
                 high: 132.09676,
               },
+            },
+            null,
+          ],
+        },
+      ],
+    };
+    assert.deepEqual(roundPlacesAll(actual, 5), expected);
+  });
+
+  test('2x2 matrix with multiple measurements', async () => {
+    const config: ConfigFile = {
+      benchmarks: [
+        {
+          name: 'foo',
+          url: 'http://example.com?foo',
+          measurement: [
+            {name: 'Metric 1', mode: 'performance', entryName: 'metric1'},
+            {name: 'Metric 2', mode: 'performance', entryName: 'metric2'}
+          ]
+        },
+        {
+          name: 'bar',
+          url: 'http://example.com?bar',
+          measurement: [
+            {name: 'Metric 1', mode: 'performance', entryName: 'metric1'},
+            {name: 'Metric 2', mode: 'performance', entryName: 'metric2'}
+          ]
+        },
+      ],
+    };
+    const results = await fakeResults(config);
+    const actual = jsonOutput(results);
+    const expected: JsonOutputFile = {
+      benchmarks: [
+        {
+          name: 'foo [Metric 1]',
+          bytesSent: 1024,
+          version: undefined,
+          measurement: {
+            name: 'Metric 1',
+            mode: 'performance',
+            entryName: 'metric1',
+          },
+          browser: {
+            name: 'chrome',
+            headless: false,
+            windowSize: {width: 1024, height: 768},
+            userAgent:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36',
+          },
+          samples: [
+            ...new Array(25).fill(5),
+            ...new Array(25).fill(15),
+          ],
+          mean: {low: 8.56459, high: 11.43541},
+          differences: [
+            null,
+            {
+              absolute: {high: 2.02998, low: -2.02998},
+              percentChange: {high: 20.29978, low: -20.29978}
+            },
+            {
+              absolute: {low: -12.02998, high: -7.97002},
+              percentChange: {low: -58.02419, high: -41.97581},
+            },
+            {
+              absolute: {high: -7.97002, low: -12.02998},
+              percentChange: {high: -41.97581, low: -58.02419}
+            }
+          ],
+        },
+        {
+          name: 'foo [Metric 2]',
+          bytesSent: 1024,
+          version: undefined,
+          measurement: {
+            name: 'Metric 2',
+            mode: 'performance',
+            entryName: 'metric2',
+          },
+          browser: {
+            name: 'chrome',
+            headless: false,
+            windowSize: {width: 1024, height: 768},
+            userAgent:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36',
+          },
+          samples: [...new Array(25).fill(5), ...new Array(25).fill(15)],
+          mean: {high: 11.43541, low: 8.56459},
+          differences: [
+            {
+              absolute: {high: 2.02998, low: -2.02998},
+              percentChange: {high: 20.29978, low: -20.29978}
+            },
+            null,
+            {
+              absolute: {high: -7.97002, low: -12.02998},
+              percentChange: {high: -41.97581, low: -58.02419}
+            },
+            {
+              absolute: {high: -7.97002, low: -12.02998},
+              percentChange: {high: -41.97581, low: -58.02419},
+            },
+          ],
+        },
+        {
+          name: 'bar [Metric 1]',
+          bytesSent: 2048,
+          version: undefined,
+          measurement: {
+            name: 'Metric 1',
+            mode: 'performance',
+            entryName: 'metric1',
+          },
+          browser: {
+            name: 'chrome',
+            headless: false,
+            windowSize: {width: 1024, height: 768},
+            userAgent:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36',
+          },
+          samples: [
+            ...new Array(25).fill(15),
+            ...new Array(25).fill(25),
+          ],
+          mean: {low: 18.56459, high: 21.43541},
+          differences: [
+            {
+              absolute: {low: 7.97002, high: 12.02998},
+              percentChange: {low: 67.90324, high: 132.09676},
+            },
+            {
+              absolute: {high: 12.02998, low: 7.97002},
+              percentChange: {high: 132.09676, low: 67.90324}
+            },
+            null,
+            {
+              absolute: {high: 2.02998, low: -2.02998},
+              percentChange: {high: 10.14989, low: -10.14989}
+            }
+          ],
+        },
+        {
+          name: 'bar [Metric 2]',
+          bytesSent: 2048,
+          version: undefined,
+          measurement: {
+            name: 'Metric 2',
+            mode: 'performance',
+            entryName: 'metric2',
+          },
+          browser: {
+            name: 'chrome',
+            headless: false,
+            windowSize: {width: 1024, height: 768},
+            userAgent:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36',
+          },
+          samples: [
+            ...new Array(25).fill(15),
+            ...new Array(25).fill(25),
+          ],
+          mean: {low: 18.56459, high: 21.43541},
+          differences: [
+            {
+              absolute: {high: 12.02998, low: 7.97002},
+              percentChange: {high: 132.09676, low: 67.90324}
+            },
+            {
+              absolute: {high: 12.02998, low: 7.97002},
+              percentChange: {high: 132.09676, low: 67.90324}
+            },
+            {
+              absolute: {high: 2.02998, low: -2.02998},
+              percentChange: {high: 10.14989, low: -10.14989}
             },
             null,
           ],

--- a/src/test/json-output_test.ts
+++ b/src/test/json-output_test.ts
@@ -65,6 +65,7 @@ suite('jsonOutput', () => {
           bytesSent: 1024,
           version: undefined,
           measurement: {
+            name: 'fcp',
             mode: 'performance',
             entryName: 'first-contentful-paint',
           },
@@ -102,6 +103,7 @@ suite('jsonOutput', () => {
           bytesSent: 2048,
           version: undefined,
           measurement: {
+            name: 'fcp',
             mode: 'performance',
             entryName: 'first-contentful-paint',
           },

--- a/src/test/test_helpers.ts
+++ b/src/test/test_helpers.ts
@@ -53,10 +53,14 @@ export async function fakeResults(configFile: ConfigFile):
     ];
     for (let measurementIndex = 0; measurementIndex < measurement.length;
          measurementIndex++) {
+      const resultName = measurement.length == 1 ?
+          name :
+          `${name} [${measurement[measurementIndex].name}]`;
       results.push({
         stats: summaryStats(millis),
         result: {
-          name,
+          name: resultName,
+          measurement: measurement[measurementIndex],
           measurementIndex,
           queryString: url.kind === 'local' ? url.queryString : '',
           version: url.kind === 'local' && url.version !== undefined ?

--- a/src/test/test_helpers.ts
+++ b/src/test/test_helpers.ts
@@ -53,7 +53,7 @@ export async function fakeResults(configFile: ConfigFile):
     ];
     for (let measurementIndex = 0; measurementIndex < measurement.length;
          measurementIndex++) {
-      const resultName = measurement.length == 1 ?
+      const resultName = measurement.length === 1 ?
           name :
           `${name} [${measurement[measurementIndex].name}]`;
       results.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,16 +51,20 @@ export interface NpmPackageJson {
 export type Measurement =
     CallbackMeasurement|PerformanceEntryMeasurement|ExpressionMeasurement;
 
-export interface CallbackMeasurement {
+export interface MeasurementBase {
+  name?: string;
+}
+
+export interface CallbackMeasurement extends MeasurementBase {
   mode: 'callback';
 }
 
-export interface PerformanceEntryMeasurement {
+export interface PerformanceEntryMeasurement extends MeasurementBase {
   mode: 'performance';
   entryName: string;
 }
 
-export interface ExpressionMeasurement {
+export interface ExpressionMeasurement extends MeasurementBase {
   mode: 'expression';
   expression: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,10 @@ export interface BenchmarkResult {
    */
   name: string;
   /**
+   * The measurement that produced this result
+   */
+  measurement: Measurement;
+  /**
    * A single page can return multiple measurements. The offset into the array
    * of measurements in the spec that this particular result corresponds to.
    */


### PR DESCRIPTION
This PR adds two primary features

## Add measurement object to JSON output

Currently, there isn't a great way for the JSON output to match results back to the benchmark and measurement that produced those results. You'd have to parse the benchmark name (`bench [measurement]`) to determine which benchmark and which measurement these results map to.

This PR adds a `measurement` field to each benchmark result that maps to the measurement config that produced that benchmark, enabling a reporter using the JSON output a programmatic way to understand the relationship between measurements and benchmarks

## Ability to specify the name of a measurement

This change gives the user an ability to name measurements, similar to how they can name benchmarks. This provides a way to simplify the displayed label in tables (in case the name of a window expression is long). This property is optional.