### PR TITLE
Fix yarn on-demand install failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tachometer": "bin/tach.js"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "if [ -f './tsconfig.json' ]; then npm run build; fi;",
     "build": "rimraf lib/ client/lib/ && mkdir lib && npm run generate-json-schema && tsc && tsc -p client/ && npm run lint",
     "generate-json-schema": "typescript-json-schema tsconfig.json ConfigFile --include src/configfile.ts --required --noExtraProps > config.schema.json",
     "lint": "tslint --project . --format stylish",


### PR DESCRIPTION
This addresses a reported and diagnosed problem caused by the Yarn package manager running package lifecycle scripts under conditions when they ordinarily would not be run by NPM (details in #186).

The strategy used to address this issue is to check for a file that is only present under conditions when we would want the `prepare` script to run: `tsconfig.json`.

Fixes #186 