### PR TITLE
Advanced git dependency swapping for monorepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add support for `name` property to measurement config
 - Include `measurement` object for each benchmark in JSON results output
+- Add advanced configuration for cloning a git repo as a dependency swap for
+  monorepos and other git layouts where the `package.json` is not at the root.
 
 ## [0.5.1] 2020-08-19
 

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ to swap in, like this:
       "name": "my-benchmark",
       "url": "my-benchmark.html",
       "packageVersions": {
-        "label": "master",
+        "label": "my-label",
         "dependencies": {
-          "my-lib": "github:MyOrg/my-lib#master",
+          "my-package": "github:MyOrg/my-repo#my-branch",
         },
       }
     },
@@ -247,23 +247,33 @@ The version for a dependency can be any of the following:
 
 - For monorepos, or other git repos where the `package.json` is not located at
   the root of the repository (which is required for NPM's git install function),
-  you can use the advanced git configuration:
+  you can use an advanced git configuration object
+  ([schema](https://github.com/Polymer/tachometer/blob/master/config.schema.json#:~:text=GitDependency))
+  in place of the NPM version string, e.g.:
 
-  ```ts
-  interface GitDependency {
-    kind: 'git';
-    // The git repository to clone. Any valid `git clone <repository>` argument
-    // (e.g. "git@github.com:webcomponents/polyfills.git").
-    repo: string;
-    // The branch, tag, or SHA to checkout (e.g. "master", "my-feature").
-    ref: string;
-    // For monorepos or other unusual file layouts, the path relative to the root
-    // of the git repo where the "package.json" for the appropriate package can be
-    // found (e.g. "packages/shadycss").
-    subdir?: string;
-    // Install, bootstrap, build, etc. commands to run before installing this
-    // package as a dependency (e.g. ["npm install", "npm run build"]).
-    setupCommands?: string[];
+  ```json
+  {
+    "benchmarks": [
+      {
+        "name": "my-benchmark",
+        "url": "my-benchmark.html",
+        "packageVersions": {
+          "label": "my-label",
+          "dependencies": {
+            "my-package": {
+              "kind": "git",
+              "repo": "git@github.com:MyOrg/my-repo.git",
+              "ref": "my-branch",
+              "subdir": "packages/my-package",
+              "setupCommands": [
+                "npm install",
+                "npm run build"
+              ]
+            }
+          },
+        }
+      },
+    ],
   }
   ```
 
@@ -273,8 +283,8 @@ advanced git install configuration is not supported from the commandline:
 
 ```
 tach mybench.html \
-  --package-version=mylib@1.0.0 \
-  --package-version=master=mylib@github:MyOrg/mylib#master
+  --package-version=my-package@1.0.0 \
+  --package-version=my-label=my-package@github:MyOrg/my-repo#my-branch
 ```
 
 When you specify a dependency to swap, the following happens:
@@ -623,9 +633,9 @@ Defaults are the same as the corresponding command-line flags.
       },
       "measure": "fcp",
       "packageVersions": {
-        "label": "master",
+        "label": "my-branch",
         "dependencies": {
-          "mylib": "github:Polymer/mylib#master",
+          "mylib": "github:Polymer/mylib#my-branch",
         },
       }
     },

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ confidence in them.
   is faster or slower, and by how much, with statistical significance.
 
 
-- [*Swap dependency versions*](#swap-npm-dependency-versions) of any NPM package
-  you depend on, to compare published versions, remote GitHub branches, or local
-  git repos.
+- [*Swap dependency versions*](#swap-npm-dependencies) of any NPM package you
+  depend on, to compare published versions, remote GitHub branches, or local git
+  repos.
 
 
 - [*Automatically sample*](#auto-sampling) until we have enough precision to
@@ -218,8 +218,58 @@ Tachometer has specialized support for swapping in custom versions of any NPM
 dependency in your `package.json`. This can be used to compare the same
 benchmark against one or more versions of a library it depends on.
 
-Use the `--package-version` flag to specify a version to swap in, with format
-`[label=]package@version`.
+Use the `benchmarks.packageVersions` JSON config property to specify the version
+to swap in, like this:
+
+```json
+{
+  "benchmarks": [
+    {
+      "name": "my-benchmark",
+      "url": "my-benchmark.html",
+      "packageVersions": {
+        "label": "master",
+        "dependencies": {
+          "my-lib": "github:MyOrg/my-lib#master",
+        },
+      }
+    },
+  ],
+}
+```
+
+The version for a dependency can be any of the following:
+
+- Any version range supported by NPM, including semver ranges, git repos, and
+  local paths. See the [NPM
+  documentation](https://docs.npmjs.com/configuring-npm/package-json.html#dependencies)
+  for more details.
+
+- For monorepos, or other git repos where the `package.json` is not located at
+  the root of the repository (which is required for NPM's git install function),
+  you can use the advanced git configuration:
+
+  ```ts
+  interface GitDependency {
+    kind: 'git';
+    // The git repository to clone. Any valid `git clone <repository>` argument
+    // (e.g. "git@github.com:webcomponents/polyfills.git").
+    repo: string;
+    // The branch, tag, or SHA to checkout (e.g. "master", "my-feature").
+    ref: string;
+    // For monorepos or other unusual file layouts, the path relative to the root
+    // of the git repo where the "package.json" for the appropriate package can be
+    // found (e.g. "packages/shadycss").
+    subdir?: string;
+    // Install, bootstrap, build, etc. commands to run before installing this
+    // package as a dependency (e.g. ["npm install", "npm run build"]).
+    setupCommands?: string[];
+  }
+  ```
+
+You can also use the `--package-version` flag to specify a version to swap in
+from the command-line, with format `[label=]package@version`. Note that the
+advanced git install configuration is not supported from the commandline:
 
 ```
 tach mybench.html \
@@ -227,7 +277,7 @@ tach mybench.html \
   --package-version=master=mylib@github:MyOrg/mylib#master
 ```
 
-When you use the `--package-version` flag, the following happens:
+When you specify a dependency to swap, the following happens:
 
 1. The `package.json` file closest to your benchmark HTML file is found.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -276,6 +276,39 @@
             ],
             "type": "object"
         },
+        "GitDependency": {
+            "additionalProperties": false,
+            "description": "Configuration for cloning a Git repo at some ref with an optional package\nsub-path for monorepos, for use as an NPM dependency.",
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "git"
+                    ],
+                    "type": "string"
+                },
+                "ref": {
+                    "type": "string"
+                },
+                "repo": {
+                    "type": "string"
+                },
+                "setupCommands": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "subdir": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "kind",
+                "ref",
+                "repo"
+            ],
+            "type": "object"
+        },
         "IEConfig": {
             "additionalProperties": false,
             "properties": {
@@ -302,7 +335,14 @@
         },
         "PackageDependencyMap": {
             "additionalProperties": {
-                "type": "string"
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/GitDependency"
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
             },
             "description": "A mapping from NPM package name to version specifier, as used in a\npackage.json's \"dependencies\" and \"devDependencies\".",
             "type": "object"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import {BenchmarkSpec} from './types';
 import {makeConfig} from './config';
 import {Server} from './server';
 import {ResultStatsWithDifferences} from './stats';
-import {prepareVersionDirectory, makeServerPlans} from './versions';
+import {prepareVersionDirectory, makeServerPlans, installGitDependency} from './versions';
 import {manualMode} from './manual';
 import {Runner} from './runner';
 import {runNpm} from './util';
@@ -118,8 +118,12 @@ $ tach http://example.com
         `--save will be removed in the next major version.`);
   }
 
-  const plans = await makeServerPlans(
+  const {plans, gitInstalls} = await makeServerPlans(
       config.root, opts['npm-install-dir'], config.benchmarks);
+
+  await Promise.all(gitInstalls.map(
+      (gitInstall) =>
+          installGitDependency(gitInstall, config.forceCleanNpmInstall)));
 
   const servers = new Map<BenchmarkSpec, Server>();
   const promises = [];

--- a/src/test/versions_test.ts
+++ b/src/test/versions_test.ts
@@ -71,6 +71,7 @@ suite('versions', () => {
           browser: defaultBrowser,
         },
 
+
         // mybench and other bench only need the default server.
         {
           name: 'mybench',
@@ -115,12 +116,13 @@ suite('versions', () => {
       ];
 
       const tempDir = '/tmp';
-      const actual = await makeServerPlans(testData, tempDir, specs);
+      const {plans: actualPlans, gitInstalls: actualGitInstalls} =
+          await makeServerPlans(testData, tempDir, specs);
 
       const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
       const v2Hash = hashStrings(path.join(testData, 'mylib'), 'v2');
 
-      const expected: ServerPlan[] = [
+      const expectedPlans: ServerPlan[] = [
         {
           specs: [specs[2], specs[3]],
           npmInstalls: [],
@@ -181,7 +183,8 @@ suite('versions', () => {
         },
       ];
 
-      assert.deepEqual(actual, expected);
+      assert.deepEqual(actualPlans, expectedPlans);
+      assert.deepEqual(actualGitInstalls, []);
     });
 
     /**
@@ -198,9 +201,7 @@ suite('versions', () => {
             urlPath: '/mybench/',
             version: {
               label: 'v1',
-              dependencyOverrides: {
-                mylib: '1.0.0',
-              },
+              dependencyOverrides: {mylib: '1.0.0'},
             },
             queryString: '',
           },
@@ -213,11 +214,11 @@ suite('versions', () => {
       ];
 
       const tempDir = '/tmp';
-      const actual =
+      const {plans: actualPlans, gitInstalls: actualGitInstalls} =
           await makeServerPlans(path.join(testData, 'mylib'), tempDir, specs);
 
       const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
-      const expected: ServerPlan[] = [
+      const expectedPlans: ServerPlan[] = [
         {
           specs: [specs[0]],
           npmInstalls: [{
@@ -243,7 +244,8 @@ suite('versions', () => {
         },
       ];
 
-      assert.deepEqual(actual, expected);
+      assert.deepEqual(actualPlans, expectedPlans);
+      assert.deepEqual(actualGitInstalls, []);
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,27 @@ export class Deferred<T> {
  * package.json's "dependencies" and "devDependencies".
  */
 export interface PackageDependencyMap {
-  [pkg: string]: string;
+  [pkg: string]: string|GitDependency;
+}
+
+/**
+ * Configuration for cloning a Git repo at some ref with an optional package
+ * sub-path for monorepos, for use as an NPM dependency.
+ */
+export interface GitDependency {
+  kind: 'git';
+  // The git repository to clone. Any valid `git clone <repository>` argument
+  // (e.g. "git@github.com:webcomponents/polyfills.git").
+  repo: string;
+  // The branch, tag, or SHA to checkout (e.g. "master", "my-feature").
+  ref: string;
+  // For monorepos or other unusual file layouts, the path relative to the root
+  // of the git repo where the "package.json" for the appropriate package can be
+  // found (e.g. "packages/shadycss").
+  subdir?: string;
+  // Install, bootstrap, build, etc. commands to run before installing this
+  // package as a dependency (e.g. ["npm install", "npm run build"]).
+  setupCommands?: string[];
 }
 
 /**

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -9,13 +9,22 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import * as childProcess from 'child_process';
 import * as crypto from 'crypto';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
+import * as util from 'util';
+
+const execFilePromise = util.promisify(childProcess.execFile);
+const execPromise = util.promisify(childProcess.exec);
 
 import {MountPoint} from './server';
-import {BenchmarkSpec, NpmPackageJson, PackageDependencyMap, PackageVersion} from './types';
-import {fileKind, runNpm} from './util';
+import {BenchmarkSpec, GitDependency, NpmPackageJson, PackageDependencyMap, PackageVersion} from './types';
+import {fileKind, runNpm, throwUnreachable} from './util';
+
+interface GitDependencyWithTempDir extends GitDependency {
+  tempDir: string;
+}
 
 /**
  * Parse an array of strings of the form <package>@<version>.
@@ -54,10 +63,11 @@ export interface NpmInstall {
 
 export async function makeServerPlans(
     benchmarkRoot: string, npmInstallRoot: string, specs: BenchmarkSpec[]):
-    Promise<ServerPlan[]> {
+    Promise<{plans: ServerPlan[], gitInstalls: GitDependencyWithTempDir[]}> {
   const keySpecs = new Map<string, BenchmarkSpec[]>();
   const keyDeps = new Map<string, PackageDependencyMap>();
   const defaultSpecs = [];
+  const gitInstalls = new Map<string, GitDependencyWithTempDir>();
   for (const spec of specs) {
     if (spec.url.kind === 'remote') {
       // No server needed for remote URLs.
@@ -93,10 +103,46 @@ export async function makeServerPlans(
     }
     arr.push(spec);
 
+
     const newDeps = {
       ...originalPackageJson.dependencies,
-      ...spec.url.version.dependencyOverrides,
     };
+    for (const pkg of Object.keys(spec.url.version.dependencyOverrides)) {
+      const version = spec.url.version.dependencyOverrides[pkg];
+      if (typeof version === 'string') {
+        // NPM dependency syntax that can be handled directly by NPM without any
+        // help from us. This includes NPM packages, file paths, git repos (but
+        // not monorepos!), etc. (see
+        // https://docs.npmjs.com/configuring-npm/package-json.html#dependencies)
+        newDeps[pkg] = version;
+      } else {
+        switch (version.kind) {
+          case 'git':
+            // NPM doesn't support directly installing from a sub-directory of a
+            // git repo, like in monorepos, so we handle those cases ourselves.
+            const hash = hashStrings(
+                pkg,
+                version.kind,
+                version.repo,
+                version.ref,
+                version.subdir || '',
+                ...(version.setupCommands || []));
+            const tempDir = path.join(npmInstallRoot, hash);
+            const tempPackageDir =
+                version.subdir ? path.join(tempDir, version.subdir) : tempDir;
+            newDeps[pkg] = tempPackageDir;
+            // We're using a Map here because we want to de-duplicate git
+            // installations that have the exact same parameters, since they can
+            // be re-used across multiple benchmarks.
+            gitInstalls.set(hash, {...version, tempDir});
+            break;
+          default:
+            throwUnreachable(
+                version.kind,
+                'Unknown dependency version kind: ' + version.kind);
+        }
+      }
+    }
     keyDeps.set(key, newDeps);
   }
 
@@ -150,7 +196,7 @@ export async function makeServerPlans(
     });
   }
 
-  return plans;
+  return {plans, gitInstalls: [...gitInstalls.values()]};
 }
 
 async function findPackageJsonPath(startDir: string):
@@ -223,4 +269,40 @@ export async function prepareVersionDirectory(
   await fsExtra.ensureDir(installDir);
   await fsExtra.writeFile(packageJsonPath, serializedPackageJson);
   await runNpm(['install'], {cwd: installDir});
+}
+
+export async function installGitDependency(
+    gitInstall: GitDependencyWithTempDir,
+    forceCleanInstall: boolean): Promise<void> {
+  if (forceCleanInstall) {
+    await fsExtra.remove(gitInstall.tempDir);
+  } else if (await fsExtra.pathExists(gitInstall.tempDir)) {
+    // TODO(aomarks) We can be smarter here: if the ref is a branch or tag, we
+    // can check if it has changed upstream with a fetch, and then re-install.
+    console.log(
+        `\nRe-using git checkout: ${gitInstall.repo}#${gitInstall.ref}`);
+    return;
+  }
+
+  console.log(`\nCloning git repo to temp dir:\n  ${gitInstall.repo}\n`);
+  await execFilePromise('git', [
+    'clone',
+    '--single-branch',
+    '--depth=1',
+    gitInstall.repo,
+    gitInstall.tempDir,
+  ]);
+
+  console.log(`\nFetching and checking out ref:\n  ${gitInstall.ref}\n`);
+  const cwdOpts = {cwd: gitInstall.tempDir};
+  await execFilePromise(
+      'git',
+      ['fetch', 'origin', '--depth=1', '--tags', gitInstall.ref],
+      cwdOpts);
+  await execFilePromise('git', ['checkout', gitInstall.ref], cwdOpts);
+
+  for (const setupCommand of gitInstall.setupCommands || []) {
+    console.log(`\nRunning setup command:\n  ${setupCommand}\n`);
+    await execPromise(setupCommand, cwdOpts);
+  }
 }


### PR DESCRIPTION
You can now specify a more advanced configuration for using a git repo when doing dependency swapping. This is especially useful for monorepos, as it allows installing a package that's in a sub-directory, as well as running arbitrary setup commands instead of just `prepare`.

We need this because we can't just use a simple `"git:"` style NPM dependency version specifier, because NPM assumes that the `package.json` is at the top-level of the repository (see https://github.com/npm/npm/issues/2974 for closed feature request to NPM to support sub-packages).

```json
"packageVersions": {
  "label": "polyfills-master",
  "dependencies": {
    "@webcomponents/webcomponentsjs": {
      "kind": "git",
      "repo": "git@github.com:webcomponents/polyfills.git",
      "ref": "master",
      "subdir": "packages/webcomponentsjs",
      "setupCommands": [
        "npm install",
        "npm run bootstrap",
        "npm run build"
      ]
    }
  }
}
```

Fixes https://github.com/Polymer/tachometer/issues/100

cc @Westbrook 
cc @e111077 