### PR TITLE
Fix git checkout bug and improve dependency swapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
   configured `ref` is still up to date. If it is stale, a fresh install will be
   performed.
 
+- When using dependency swapping, temp directories will be deleted when there is
+  an installation failure, so that they are not re-used in a broken state.
+
 ## [0.5.2] 2020-09-08
 
 - Add advanced configuration for cloning a git repo as a dependency swap for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix `git checkout` errors when using advanced git-based dependency swapping.
+
+- When using dependency swapping, a fresh install will now be performed whenever
+  any dependency version has changed (either in the original `package.json`, or
+  in the dependency-swap configuration). The `label` field is no longer
+  significant in this respect.
+
+- When using advanced git-based dependency swapping `{kind: 'git', ...}`, a
+  query will now always be made to the remote git repo to determine if the
+  configured `ref` is still up to date. If it is stale, a fresh install will be
+  performed.
 
 ## [0.5.2] 2020-09-08
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -166,7 +166,7 @@
             "additionalProperties": false,
             "properties": {
                 "dependencies": {
-                    "$ref": "#/definitions/PackageDependencyMap",
+                    "$ref": "#/definitions/ExtendedPackageDependencyMap",
                     "description": "Map from NPM package to version. Any version syntax supported by NPM is\nsupported here."
                 },
                 "label": {
@@ -224,6 +224,20 @@
                 "expression",
                 "mode"
             ],
+            "type": "object"
+        },
+        "ExtendedPackageDependencyMap": {
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/GitDependency"
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            },
+            "description": "Tachometer's extensions to the NPM \"dependencies\" field, which allows for\nmore advanced configurations.",
             "type": "object"
         },
         "FirefoxConfig": {
@@ -331,20 +345,6 @@
             "required": [
                 "name"
             ],
-            "type": "object"
-        },
-        "PackageDependencyMap": {
-            "additionalProperties": {
-                "anyOf": [
-                    {
-                        "$ref": "#/definitions/GitDependency"
-                    },
-                    {
-                        "type": "string"
-                    }
-                ]
-            },
-            "description": "A mapping from NPM package name to version specifier, as used in a\npackage.json's \"dependencies\" and \"devDependencies\".",
             "type": "object"
         },
         "PerformanceEntryMeasurement": {

--- a/src/configfile.ts
+++ b/src/configfile.ts
@@ -15,7 +15,7 @@ import * as jsonschema from 'jsonschema';
 import {BrowserConfig, BrowserName, parseBrowserConfigString, validateBrowserConfig} from './browser';
 import {Config, parseHorizons, urlFromLocalPath} from './config';
 import * as defaults from './defaults';
-import {BenchmarkSpec, Measurement, measurements, PackageDependencyMap} from './types';
+import {BenchmarkSpec, ExtendedPackageDependencyMap, Measurement, measurements} from './types';
 import {isHttpUrl} from './util';
 
 /**
@@ -266,7 +266,7 @@ interface ConfigFilePackageVersion {
    * Map from NPM package to version. Any version syntax supported by NPM is
    * supported here.
    */
-  dependencies: PackageDependencyMap;
+  dependencies: ExtendedPackageDependencyMap;
 }
 
 /**

--- a/src/test/versions_test.ts
+++ b/src/test/versions_test.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 
 import * as defaults from '../defaults';
 import {BenchmarkSpec} from '../types';
-import {hashStrings, makeServerPlans, ServerPlan} from '../versions';
+import {hashStrings, makeServerPlans, ServerPlan, tachometerVersion} from '../versions';
 import {testData} from './test_helpers';
 
 const defaultBrowser = {
@@ -119,8 +119,14 @@ suite('versions', () => {
       const {plans: actualPlans, gitInstalls: actualGitInstalls} =
           await makeServerPlans(testData, tempDir, specs);
 
-      const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
-      const v2Hash = hashStrings(path.join(testData, 'mylib'), 'v2');
+      const v1Hash = hashStrings(
+          tachometerVersion,
+          path.join(testData, 'mylib', 'package.json'),
+          JSON.stringify([['mylib', '1.0.0'], ['otherlib', '0.0.0']]));
+      const v2Hash = hashStrings(
+          tachometerVersion,
+          path.join(testData, 'mylib', 'package.json'),
+          JSON.stringify([['mylib', '2.0.0'], ['otherlib', '0.0.0']]));
 
       const expectedPlans: ServerPlan[] = [
         {
@@ -217,7 +223,10 @@ suite('versions', () => {
       const {plans: actualPlans, gitInstalls: actualGitInstalls} =
           await makeServerPlans(path.join(testData, 'mylib'), tempDir, specs);
 
-      const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
+      const v1Hash = hashStrings(
+          tachometerVersion,
+          path.join(testData, 'mylib', 'package.json'),
+          JSON.stringify([['mylib', '1.0.0'], ['otherlib', '0.0.0']]));
       const expectedPlans: ServerPlan[] = [
         {
           specs: [specs[0]],

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,14 @@ export class Deferred<T> {
  * package.json's "dependencies" and "devDependencies".
  */
 export interface PackageDependencyMap {
+  [pkg: string]: string;
+}
+
+/**
+ * Tachometer's extensions to the NPM "dependencies" field, which allows for
+ * more advanced configurations.
+ */
+export interface ExtendedPackageDependencyMap {
   [pkg: string]: string|GitDependency;
 }
 
@@ -58,7 +66,7 @@ export interface GitDependency {
  */
 export interface PackageVersion {
   label: string;
-  dependencyOverrides: PackageDependencyMap;
+  dependencyOverrides: ExtendedPackageDependencyMap;
 }
 
 /** The subset of the format of an NPM package.json file we care about. */


### PR DESCRIPTION
Fixes a bug with the new git dependency swapping feature, and improves temp dir caching behavior.

1. Fix error in the way we checked out git refs.

2. Always query the origin git repo and ask it to resolve refs to hashes. Use this SHA as the hash/temp directory name so that we never fall behind the origin.

3. Use the actual dependency versions to determine the identity of an NPM install directory, instead of the label.

4. Write a special file to the temp directory when installation succeeds. If the next time, we find it's not there, we assume the installation failed and re-install from scratch.

5. Simplify some code.

Fixes https://github.com/Polymer/tachometer/issues/190