### PR TITLE
Add all browser config parameters to signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix bug where a unique browser would not be launched if the only difference
+  between browser configurations was `binary`, `addArguments`,
+  `removeArguments`, `cpuThrottlingRate` or `preferences`.
 
 ## [0.5.3] 2020-09-11
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -85,9 +85,14 @@ export function browserSignature(config: BrowserConfig): string {
   return JSON.stringify([
     config.name,
     config.headless,
-    config.remoteUrl || '',
+    config.remoteUrl ?? '',
     config.windowSize.width,
     config.windowSize.height,
+    config.binary ?? '',
+    config.addArguments ?? [],
+    config.removeArguments ?? [],
+    config.cpuThrottlingRate ?? 1,
+    config.preferences ?? {},
   ]);
 }
 


### PR DESCRIPTION
We launch a new browser for each unique browser configuration. However, we were not considering any of the following fields when deciding what a unique browser was: `binary`, `addArguments`, `removeArguments`, `cpuThrottlingRate` or `preferences`.