### PR TITLE
Resolve git file paths to absolute before npm install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix bug in dependency swapping where local file paths in `git` dependencies
+  would fail to install if they were relative.
 
 ## [0.5.5] 2020-09-21
 


### PR DESCRIPTION
Previously, an install error would occur if you specified a dependency substitution like this:

```js
"my-dep": {
  "kind": "git",
  "repo": "../",
  "ref": "main",
  "setupCommands": [
    "npm i",
  ]
}
```

This happened because when `repo` is a relative path, it was getting evaluated as-is from the *temp* directory we generate for each install. Now, we first resolve such relative paths to absolute paths before install.

Fixes https://github.com/Polymer/tachometer/issues/202

cc @43081j