### PR TITLE
Upgrade systeminformation for legacy JSON output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "semver": "^7.1.1",
         "source-map-support": "^0.5.16",
         "strip-ansi": "^6.0.0",
-        "systeminformation": "^4.32.0",
+        "systeminformation": "^5.3.3",
         "table": "^6.0.7",
         "ua-parser-js": "^0.7.19"
       },
@@ -64,7 +64,6 @@
         "@types/progress": "^2.0.3",
         "@types/rimraf": "^3.0.0",
         "@types/semver": "^7.3.1",
-        "@types/systeminformation": "^3.54.1",
         "@types/ua-parser-js": "^0.7.32",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
@@ -612,15 +611,6 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/systeminformation": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@types/systeminformation/-/systeminformation-3.54.1.tgz",
-      "integrity": "sha512-vvisj2mdWygyc0jk/5XtSVq9gtxCmF3nrGwv8wVway8pwNRhtPji/MU9dc1L0F6rl0F/NFIHa4ScRU7wmNaHmg==",
-      "dev": true,
-      "dependencies": {
-        "systeminformation": "*"
       }
     },
     "node_modules/@types/table": {
@@ -3302,9 +3292,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.9.tgz",
-      "integrity": "sha512-jvc4DlJeXazsen2riPDR97GSaHNCmoL+mgfB8IXxmpNpNd7kv5MfkuihXEmF1/prBFtqzUA2lxnt1qp4maOMQA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.3.3.tgz",
+      "integrity": "sha512-s9tCz3GQfJ3L5S7KwI3k6jpSPPj1AR1ZoTqtG0UITtA01+1LAeOYz2pzCisCq9XD/KNTuHUl/AXE3zgvy+OR6Q==",
       "os": [
         "darwin",
         "linux",
@@ -3319,6 +3309,10 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/table": {
@@ -4630,15 +4624,6 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
-      }
-    },
-    "@types/systeminformation": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@types/systeminformation/-/systeminformation-3.54.1.tgz",
-      "integrity": "sha512-vvisj2mdWygyc0jk/5XtSVq9gtxCmF3nrGwv8wVway8pwNRhtPji/MU9dc1L0F6rl0F/NFIHa4ScRU7wmNaHmg==",
-      "dev": true,
-      "requires": {
-        "systeminformation": "*"
       }
     },
     "@types/table": {
@@ -6806,9 +6791,9 @@
       }
     },
     "systeminformation": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.9.tgz",
-      "integrity": "sha512-jvc4DlJeXazsen2riPDR97GSaHNCmoL+mgfB8IXxmpNpNd7kv5MfkuihXEmF1/prBFtqzUA2lxnt1qp4maOMQA=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.3.3.tgz",
+      "integrity": "sha512-s9tCz3GQfJ3L5S7KwI3k6jpSPPj1AR1ZoTqtG0UITtA01+1LAeOYz2pzCisCq9XD/KNTuHUl/AXE3zgvy+OR6Q=="
     },
     "table": {
       "version": "6.0.7",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "semver": "^7.1.1",
     "source-map-support": "^0.5.16",
     "strip-ansi": "^6.0.0",
-    "systeminformation": "^4.32.0",
+    "systeminformation": "^5.3.3",
     "table": "^6.0.7",
     "ua-parser-js": "^0.7.19"
   },
@@ -86,7 +86,6 @@
     "@types/progress": "^2.0.3",
     "@types/rimraf": "^3.0.0",
     "@types/semver": "^7.3.1",
-    "@types/systeminformation": "^3.54.1",
     "@types/ua-parser-js": "^0.7.32",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/src/json-output.ts
+++ b/src/json-output.ts
@@ -135,16 +135,16 @@ export async function legacyJsonOutput(results: BenchmarkResult[]):
         manufacturer: cpu.manufacturer,
         model: cpu.model,
         family: cpu.family,
-        speed: cpu.speed,
+        speed: cpu.speed.toFixed(2),
         cores: cpu.cores,
       },
       load: {
-        average: currentLoad.avgload,
-        current: currentLoad.currentload,
+        average: currentLoad.avgLoad,
+        current: currentLoad.currentLoad,
       },
       battery: {
-        hasBattery: battery.hasbattery,
-        connected: battery.acconnected,
+        hasBattery: battery.hasBattery,
+        connected: battery.acConnected,
       },
       memory: {
         total: memory.total,


### PR DESCRIPTION
The `systeminformation` package has a security vulnerability that is causing an alert to popup in my repos. This PR upgrades the dep to the fixed version. It ships with its own TS types so the additional `@types/systeminformation` package is no longer necessary.

Alternatively, we could consider removing the legacy JSON output since it is legacy. But since that is a breaking change I opt'ed for the safer PR first :) 

Replaces #208 