### PR TITLE
Fix windows path in generated trace filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix bug where log files would be created with '\' backslash names instead of
+  nested directories.
 
 ## [0.5.9] 2021-04-22
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -356,7 +356,7 @@ export class Runner {
 
     const logDir = spec.browser.trace.logDir;
     await fsExtra.writeFile(
-        logDir + `\\log-${sampleLabel}.json`,
+        logDir + `/log-${sampleLabel}.json`,
         // Convert perf logs into a format about:tracing can parse
         '[\n' +
             perfEntries.map((e) => JSON.parse(e.message).message)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -27,6 +27,7 @@ import * as github from './github';
 import {Server, Session} from './server';
 import {specUrl} from './specs';
 import {wait} from './util';
+import * as pathlib from 'path';
 
 interface Browser {
   name: string;
@@ -356,7 +357,7 @@ export class Runner {
 
     const logDir = spec.browser.trace.logDir;
     await fsExtra.writeFile(
-        logDir + `/log-${sampleLabel}.json`,
+        pathlib.join(logDir, `log-${sampleLabel}.json`),
         // Convert perf logs into a format about:tracing can parse
         '[\n' +
             perfEntries.map((e) => JSON.parse(e.message).message)


### PR DESCRIPTION
Currently this generates filenames like `preact-local\log-auto-sample-01.json`.