### PR TITLE
Various README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ Defaults are the same as the corresponding command-line flags.
   "root": "./benchmarks",
   "sampleSize": 50,
   "timeout": 3,
-  "autoSampleConditions": ["0%", "1%"],
+  "horizons": ["0%", "1%"],
   "benchmarks": [
     {
       "name": "foo",

--- a/README.md
+++ b/README.md
@@ -332,16 +332,9 @@ This table tells us:
 Loosely speaking, a confidence interval is a range of plausible values for a
 parameter like runtime, and the _confidence level_ (which tachometer always
 fixes to _95%_) corresponds to the degree of confidence we have that interval
-contains the _true value_ of that parameter.
-
-More precisely speaking, the 95% confidence level describes the _long-run
-proportion of confidence intervals that will contain the true value_.
-Hypothetically, if you run tachometer over and over again in the same
-configuration, then while you'll get a slightly different confidence interval
-every time, it should be the case that _95% of those confidence intervals will
-contain the true value_. See
-[Wikipedia](https://en.wikipedia.org/wiki/onfidence_interval#Meaning_and_interpretation)
-for more information.
+contains the _true value_ of that parameter. See
+[Wikipedia](https://en.wikipedia.org/wiki/Confidence_interval#Meaning_and_interpretation)
+for more information about confidence intervals.
 
 ```
     <------------->   Wider confidence interval
@@ -354,23 +347,12 @@ for more information.
 -1%      -0.5%       0%      +0.5%      +1%
 ```
 
-In general, we want narrower confidence intervals. Three knobs can do this:
-
-1. Dropping the chosen confidence level. _This is not a good idea!_ We want our
-   results to be _consistently reported with high confidence_, so we always use
-   95% confidence intervals.
-
-2. Decreasing the variation in the benchmark timing measurements. _This is hard
-   to do_. Many factors lead to variation in timing measurements, most of which
-   are very difficult to control, including some that are [intentionally built
-   in](https://developers.google.com/web/updates/2018/02/meltdown-spectre#high-resolution_timers)!
-
-3. Increasing the sample size. The [central limit
-   theorem](https://en.wikipedia.org/wiki/Central_limit_theorem) means that,
-   even when we have high variance data, and even when that data is not normally
-   distributed, as we take more and more samples, we'll be able to calculate a
-   more and more precise estimate of the true mean of the data. **Increasing the
-   sample size is the main knob we have.**
+The way tachometer shrinks confidence intervals is by **increasing the sample
+size**. The [central limit
+theorem](https://en.wikipedia.org/wiki/Central_limit_theorem) means that, even
+when we have high variance data, and even when that data is not normally
+distributed, as we take more and more samples, we'll be able to calculate a more
+and more precise estimate of the true mean of the data.
 
 ## Swap NPM dependencies
 

--- a/README.md
+++ b/README.md
@@ -130,25 +130,41 @@ You can change this duration with the `--timeout` flag or the `timeout` JSON
 config option, measured in minutes. Set `--timeout=0` to disable auto sampling
 entirely. Set `--timeout=60` to sample for up to an hour.
 
-### Stopping conditions
+### Horizons
 
-You can also control which statistical conditions tachometer should check for
-when deciding when to stop auto-sampling by configuring **_horizons_**.
+You can also configure which statistical conditions tachometer should check for
+when deciding when to stop auto sampling by configuring _horizons_.
 
-A horizon can be thought of as a _point of interest_ on the number-line of
-either absolute milliseconds, or relative percent change. By setting a horizon,
-you are asking tachometer to try to _shrink the confidence interval until it is
-unambiguously placed on one side or the other of that horizon_.
+To set horizons from the command-line, use the `--horizon` flag with a
+comma-delimited list:
 
-| Example horizon | Question                                                   |
-| --------------- | ---------------------------------------------------------- |
-| `0%`            | Is A faster or slower than B _at all_? (The **default**)   |
-| `10%`           | Is A faster or slower than B by at least 10%?              |
-| `+10%`          | Is A slower than B by at least 10%?                        |
-| `-10%`          | Is A faster than B by at least 10%?                        |
-| `-10%,+10%`     | (Same as `10%`)                                            |
-| `0%,10%,100%`   | Is A at all, a little, or a lot slower or faster than B?   |
-| `0.5ms`         | Is A faster or slower than B by at least 0.5 milliseconds? |
+```sh
+--horizon=0%,10%
+```
+
+To set horizons from a JSON config file, use the `horizons` property with an
+array of strings (including if there is only one condition):
+
+```json
+{
+  "horizons": ["0%", "10%"]
+}
+```
+
+A horizon can be thought of as a point of interest on the number-line of either
+absolute milliseconds, or relative percent change. By setting a horizon, you are
+asking tachometer to try to shrink the confidence interval until it is
+unambiguously placed on one side or the other of that horizon.
+
+| Example horizon     | Question                                                   |
+| ------------------- | ---------------------------------------------------------- |
+| `0%`                | Is A faster or slower than B _at all_? (The **default**)   |
+| `10%`               | Is A faster or slower than B by at least 10%?              |
+| `+10%`              | Is A slower than B by at least 10%?                        |
+| `-10%`              | Is A faster than B by at least 10%?                        |
+| `-10%`, `+10%`      | (Same as `10%`)                                            |
+| `0%`, `10%`, `100%` | Is A at all, a little, or a lot slower or faster than B?   |
+| `0.5ms`             | Is A faster or slower than B by at least 0.5 milliseconds? |
 
 In the following example, we have set `--horizon=10%`, meaning we are interested
 in knowing whether A differs from B by at least 10% in either direction. The
@@ -179,8 +195,7 @@ know that whatever the difference is, it is neither faster nor slower than 10%
 (and if we did want to know, we could add `0` to our horizons).
 
 Note that, if the _actual_ difference is very close to a horizon, then it is
-likely that the stopping condition will never be met, and the timeout will
-expire.
+likely that the horizon will never be met, and the timeout will expire.
 
 ## Measurement modes
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,18 @@
 > tachometer is a tool for running benchmarks in web browsers. It uses repeated
 > sampling and statistics to reliably identify even tiny differences in runtime.
 
+###### [Install](#install) | [Usage](#usage) | [Why?](#why) | [Example](#example) | [Features](#features) | [Sample Size](#sample-size) | [Auto sampling](#auto-sampling) | [Measurement modes](#measurement-modes) | [Average Runtime](#average-runtime) | [Difference table](#difference-table) | [Swap NPM dependencies](#swap-npm-dependencies) | [Confidence intervals](#confidence-intervals) | [JavaScript module imports](#javascript-module-imports) | [Browsers](#browsers) | [Performance traces](#performance-traces) | [Remote control](#remote-control) | [Config file](#config-file) | [CLI usage](#cli-usage)
+
 ## Install
 
 ```sh
 npm i tachometer
+```
+
+## Usage
+
+```sh
+npx tachometer bench1.html [bench2.html ...]
 ```
 
 ## Why?
@@ -15,12 +23,6 @@ Even if you run the same JavaScript, on the same browser, on the same machine,
 on the same day, you'll still get a different result every time. But if you take
 enough _repeated samples_ and apply the right statistics, you can reliably
 identify even tiny differences in runtime.
-
-## Usage
-
-```sh
-npx tachometer bench1.html [bench2.html ...]
-```
 
 ## Example
 
@@ -558,7 +560,7 @@ For example, using the standard location of the default user profile on macOS:
 }
 ```
 
-### Performance traces
+## Performance traces
 
 Once you determine that something is slower or faster in comparison to something
 else, investigating why is natural next step. To assist in determining why,
@@ -770,7 +772,7 @@ Which is equivalent to:
 }
 ```
 
-## Usage
+## CLI usage
 
 Run a benchmark from a local file:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tachometer [![Build Status](https://github.com/Polymer/tachometer/actions/workflows/tests.yml/badge.svg)](https://github.com/Polymer/tachometer/actions/workflows/tests.yml) [![NPM  package](https://img.shields.io/npm/v/tachometer.svg)](https://npmjs.org/package/tachometer)
+# tachometer [![Build Status](https://github.com/Polymer/tachometer/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/Polymer/tachometer/actions/workflows/tests.yaml?query=branch%3Amain) [![NPM  package](https://img.shields.io/npm/v/tachometer.svg)](https://npmjs.org/package/tachometer)
 
 > tachometer is a tool for running benchmarks in web browsers. It uses repeated
 > sampling and statistics to reliably identify even the smallest differences in

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "npm run build && mocha 'lib/test/**/*.js'"
+    "test": "npm run test:unit && npm run test:e2e",
+    "test:unit": "mocha \"lib/test/**/*_test.js\" --grep \".*e2e.*\" --invert",
+    "test:e2e": "mocha \"lib/test/**/*_test.js\" --grep \".*e2e.*\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Improved the README:
- Added a table of contents.
- New introduction example that shows comparing two benchmarks, instead of just one.
- Consolidated and moved around a few sections.
- Generally improved/made more concise some of the wording.
- Fixed one or two errors/typos.
- Fixed the test status badge.

Also threw this in:
- Separate `unit` vs `e2e` tests in `package.json`.

Fixes https://github.com/Polymer/tachometer/issues/221
Fixes https://github.com/Polymer/tachometer/issues/223