### PR TITLE
Fix: Redirect auto-sample logging to stderr

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -243,7 +243,7 @@ export class Runner {
           );
           const mins = Math.floor(remainingSecs / 60);
           const secs = remainingSecs % 60;
-          process.stdout.write(
+          process.stderr.write(
             `\r${spinner[run % spinner.length]} Auto-sample ${sample} ` +
               `(timeout in ${mins}m${secs}s)` +
               ansi.erase.inLine(0)


### PR DESCRIPTION
The auto-sample logging output in runner.ts was previously directed to stdout. This change redirects the logging output to stderr.

We are capturing stdout in order to change the formatting a little bit, but we would still like to see the auto-sampling output.

I don't know how to test this out though.